### PR TITLE
feat(donor-pwa): Event-centric navigation with read-only views

### DIFF
--- a/frontend/donor-pwa/src/components/layout/EventSelector.tsx
+++ b/frontend/donor-pwa/src/components/layout/EventSelector.tsx
@@ -1,0 +1,193 @@
+/**
+ * EventSelector Component
+ * Dropdown selector for event context in the donor PWA sidebar
+ *
+ * Business Rules:
+ * - Shows events the user is registered for
+ * - Shows events the user has admin access to
+ * - Selecting an event navigates to that event's page
+ * - Shows event name, date, and NPO name
+ */
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@/components/ui/sidebar'
+import { useEventContext } from '@/hooks/use-event-context'
+import { Calendar, ChevronsUpDown, Shield } from 'lucide-react'
+
+export function EventSelector() {
+  const { isMobile } = useSidebar()
+  const {
+    selectedEventId,
+    selectedEventName,
+    availableEvents,
+    selectEvent,
+    hasEvents,
+  } = useEventContext()
+
+  // Get selected event's logo if available
+  const selectedEvent = availableEvents.find((e) => e.id === selectedEventId)
+  const selectedEventLogo = selectedEvent?.logo_url
+
+  // Format date for display
+  const formatEventDate = (dateStr?: string | null) => {
+    if (!dateStr) return null
+    const date = new Date(dateStr)
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
+
+  // No events state
+  if (!hasEvents) {
+    return (
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton size="lg" className="cursor-default" disabled>
+            <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
+              <Calendar className="size-4" />
+            </div>
+            <div className="grid flex-1 text-start text-sm leading-tight">
+              <span className="truncate font-semibold">No Events</span>
+              <span className="text-muted-foreground truncate text-xs">
+                Register for an event
+              </span>
+            </div>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    )
+  }
+
+  // Single event - show non-clickable display
+  if (availableEvents.length === 1) {
+    const event = availableEvents[0]
+    return (
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton size="lg" className="cursor-default" disabled>
+            <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center overflow-hidden rounded-lg">
+              {selectedEventLogo ? (
+                <img
+                  src={selectedEventLogo}
+                  alt={selectedEventName}
+                  className="size-full object-cover"
+                />
+              ) : (
+                <Calendar className="size-4" />
+              )}
+            </div>
+            <div className="grid flex-1 text-start text-sm leading-tight">
+              <span className="truncate font-semibold">{event.name}</span>
+              <span className="text-muted-foreground truncate text-xs">
+                {event.npo_name || formatEventDate(event.event_date) || 'Event'}
+              </span>
+            </div>
+            {event.has_admin_access && (
+              <Shield className="text-primary size-4" />
+            )}
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    )
+  }
+
+  // Multiple events - show dropdown
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center overflow-hidden rounded-lg">
+                {selectedEventLogo ? (
+                  <img
+                    src={selectedEventLogo}
+                    alt={selectedEventName}
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <Calendar className="size-4" />
+                )}
+              </div>
+              <div className="grid flex-1 text-start text-sm leading-tight">
+                <span className="truncate font-semibold">{selectedEventName}</span>
+                <span className="text-muted-foreground truncate text-xs">
+                  {selectedEvent?.npo_name ||
+                    formatEventDate(selectedEvent?.event_date) ||
+                    'Select event'}
+                </span>
+              </div>
+              {selectedEvent?.has_admin_access && (
+                <Shield className="text-primary size-4" />
+              )}
+              <ChevronsUpDown className="ms-auto" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+            align="start"
+            side={isMobile ? 'bottom' : 'right'}
+            sideOffset={4}
+          >
+            <DropdownMenuLabel className="text-muted-foreground text-xs">
+              My Events
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {availableEvents.map((event) => (
+              <DropdownMenuItem
+                key={event.id}
+                onClick={() => selectEvent(event)}
+                className="gap-2 p-2"
+              >
+                <div className="flex size-6 items-center justify-center overflow-hidden rounded-sm border">
+                  {event.logo_url ? (
+                    <img
+                      src={event.logo_url}
+                      alt={event.name}
+                      className="size-full object-cover"
+                    />
+                  ) : (
+                    <Calendar className="size-4 shrink-0" />
+                  )}
+                </div>
+                <div className="flex-1">
+                  <div className="flex items-center gap-2 font-medium">
+                    {event.name}
+                    {event.has_admin_access && (
+                      <Shield className="text-primary size-3" />
+                    )}
+                  </div>
+                  <div className="text-muted-foreground text-xs">
+                    {event.npo_name && <span>{event.npo_name}</span>}
+                    {event.npo_name && event.event_date && <span> · </span>}
+                    {event.event_date && <span>{formatEventDate(event.event_date)}</span>}
+                  </div>
+                </div>
+                {selectedEventId === event.id && (
+                  <span className="text-primary text-xs">✓</span>
+                )}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/frontend/donor-pwa/src/components/layout/app-sidebar.tsx
+++ b/frontend/donor-pwa/src/components/layout/app-sidebar.tsx
@@ -6,51 +6,48 @@ import {
   SidebarRail,
 } from '@/components/ui/sidebar'
 import { useLayout } from '@/context/layout-provider'
-import { Building2, Calendar, LayoutDashboard, Users } from 'lucide-react'
-import { useRoleBasedNav } from '@/hooks/use-role-based-nav'
+import { Settings, User } from 'lucide-react'
 import { sidebarData } from './data/sidebar-data'
+import { EventSelector } from './EventSelector'
 import { NavGroup } from './nav-group'
 import { NavUser } from './nav-user'
-import { NpoSelector } from './NpoSelector'
 import type { NavGroup as NavGroupType } from './types'
 
-// Map icon string names to lucide-react icon components
-const iconMap = {
-  LayoutDashboard,
-  Building2,
-  Calendar,
-  Users,
-}
-
+/**
+ * Donor PWA Sidebar
+ *
+ * Simplified sidebar for donors:
+ * - Event selector dropdown (shows registered events)
+ * - Settings navigation only (profile, password, consent)
+ * - No dashboard, no NPO management, no user management
+ */
 export function AppSidebar() {
   const { collapsible, variant } = useLayout()
-  const { navItems } = useRoleBasedNav()
 
-  // Convert useRoleBasedNav items to sidebar structure
-  const roleBasedNavGroup: NavGroupType = {
-    title: 'General',
-    items: navItems.map((item) => ({
-      title: item.title,
-      url: item.href,
-      badge: typeof item.badge === 'number' ? String(item.badge) : item.badge,
-      icon: item.icon ? iconMap[item.icon as keyof typeof iconMap] : undefined,
-    })),
+  // Donor PWA only shows settings navigation
+  const donorNavGroup: NavGroupType = {
+    title: 'Account',
+    items: [
+      {
+        title: 'Profile',
+        url: '/settings',
+        icon: User,
+      },
+      {
+        title: 'Settings',
+        url: '/settings/password',
+        icon: Settings,
+      },
+    ],
   }
-
-  // Only show the role-based navigation group
-  const filteredNavGroups = [roleBasedNavGroup]
 
   return (
     <Sidebar collapsible={collapsible} variant={variant}>
       <SidebarHeader>
-        <NpoSelector />
-
-        {/* NpoSelector replaces TeamSwitcher for NPO context selection */}
+        <EventSelector />
       </SidebarHeader>
       <SidebarContent>
-        {filteredNavGroups.map((props) => (
-          <NavGroup key={props.title} {...props} />
-        ))}
+        <NavGroup {...donorNavGroup} />
       </SidebarContent>
       <SidebarFooter>
         <NavUser user={sidebarData.user} />

--- a/frontend/donor-pwa/src/features/events/EventViewPage.tsx
+++ b/frontend/donor-pwa/src/features/events/EventViewPage.tsx
@@ -1,0 +1,450 @@
+/**
+ * EventViewPage
+ * Read-only event page for donors in the PWA
+ * Shows event details, sponsors, auction items - no editing
+ */
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useAuctionItemStore } from '@/stores/auctionItemStore'
+import { useEventStore } from '@/stores/event-store'
+import { useSponsorStore } from '@/stores/sponsorStore'
+import { useNavigate, useParams } from '@tanstack/react-router'
+import {
+  Calendar,
+  Gavel,
+  Heart,
+  MapPin,
+  Shirt,
+  User,
+} from 'lucide-react'
+import { useCallback, useEffect } from 'react'
+import { toast } from 'sonner'
+
+export function EventViewPage() {
+  const navigate = useNavigate()
+  const { eventId } = useParams({ strict: false }) as { eventId: string }
+  const { currentEvent, eventsLoading, loadEventById } = useEventStore()
+  const { sponsors, fetchSponsors } = useSponsorStore()
+  const { items: auctionItems, fetchAuctionItems } = useAuctionItemStore()
+
+  const loadEvent = useCallback(() => {
+    if (eventId) {
+      loadEventById(eventId).catch(() => {
+        toast.error('Failed to load event')
+        navigate({ to: '/home' })
+      })
+    }
+  }, [eventId, loadEventById, navigate])
+
+  useEffect(() => {
+    loadEvent()
+  }, [loadEvent])
+
+  // Load sponsors
+  useEffect(() => {
+    if (eventId) {
+      fetchSponsors(eventId).catch(() => { })
+    }
+  }, [eventId, fetchSponsors])
+
+  // Load auction items
+  useEffect(() => {
+    if (eventId) {
+      fetchAuctionItems(eventId).catch(() => { })
+    }
+  }, [eventId, fetchAuctionItems])
+
+  // Format datetime for display
+  const formatDateTime = (dateTimeStr?: string | null) => {
+    if (!dateTimeStr) return { date: 'TBD', time: '' }
+    const dt = new Date(dateTimeStr)
+    return {
+      date: dt.toLocaleDateString('en-US', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      }),
+      time: dt.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+      }),
+    }
+  }
+
+  const formatCurrency = (amount?: number | null) => {
+    if (amount == null) return 'TBD'
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(amount)
+  }
+
+  // Get banner image from media
+  const getBannerUrl = () => {
+    if (!currentEvent?.media) return null
+    const banner = currentEvent.media.find(
+      (m) => m.media_type === 'image' && m.display_order === 0
+    )
+    return banner?.file_url || currentEvent.media[0]?.file_url
+  }
+
+  if (eventsLoading) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <div className="text-center">
+          <div className="border-primary mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2"></div>
+          <p className="text-muted-foreground">Loading event...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!currentEvent) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <div className="text-center">
+          <h2 className="text-xl font-semibold">Event not found</h2>
+          <p className="text-muted-foreground mt-2">
+            This event may have been removed or you don't have access.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const { date, time } = formatDateTime(currentEvent.event_datetime)
+  const bannerUrl = getBannerUrl()
+
+  return (
+    <div className="container mx-auto space-y-6 px-4 py-6">
+      {/* Event Header */}
+      <div className="space-y-4">
+        {/* Banner Image */}
+        {bannerUrl && (
+          <div className="relative h-48 w-full overflow-hidden rounded-lg md:h-64">
+            <img
+              src={bannerUrl}
+              alt={currentEvent.name}
+              className="h-full w-full object-cover"
+            />
+          </div>
+        )}
+
+        {/* Event Title and Status */}
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold md:text-3xl">{currentEvent.name}</h1>
+            {currentEvent.tagline && (
+              <p className="text-muted-foreground mt-1">{currentEvent.tagline}</p>
+            )}
+            {currentEvent.npo_name && (
+              <p className="text-muted-foreground text-sm">
+                by {currentEvent.npo_name}
+              </p>
+            )}
+          </div>
+          <Badge
+            variant={
+              currentEvent.status === 'active'
+                ? 'default'
+                : currentEvent.status === 'draft'
+                  ? 'secondary'
+                  : 'outline'
+            }
+          >
+            {currentEvent.status}
+          </Badge>
+        </div>
+      </div>
+
+      {/* Quick Info Cards */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardContent className="flex items-center gap-3 pt-6">
+            <Calendar className="text-primary h-5 w-5" />
+            <div>
+              <p className="text-sm font-medium">Date & Time</p>
+              <p className="text-muted-foreground text-sm">{date}</p>
+              {time && <p className="text-muted-foreground text-sm">{time}</p>}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="flex items-center gap-3 pt-6">
+            <MapPin className="text-primary h-5 w-5" />
+            <div>
+              <p className="text-sm font-medium">Location</p>
+              <p className="text-muted-foreground text-sm">
+                {currentEvent.venue_name || 'TBD'}
+              </p>
+              {currentEvent.venue_city && currentEvent.venue_state && (
+                <p className="text-muted-foreground text-sm">
+                  {currentEvent.venue_city}, {currentEvent.venue_state}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {currentEvent.attire && (
+          <Card>
+            <CardContent className="flex items-center gap-3 pt-6">
+              <Shirt className="text-primary h-5 w-5" />
+              <div>
+                <p className="text-sm font-medium">Attire</p>
+                <p className="text-muted-foreground text-sm">
+                  {currentEvent.attire}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {currentEvent.primary_contact_name && (
+          <Card>
+            <CardContent className="flex items-center gap-3 pt-6">
+              <User className="text-primary h-5 w-5" />
+              <div>
+                <p className="text-sm font-medium">Contact</p>
+                <p className="text-muted-foreground text-sm">
+                  {currentEvent.primary_contact_name}
+                </p>
+                {currentEvent.primary_contact_email && (
+                  <p className="text-muted-foreground text-xs">
+                    {currentEvent.primary_contact_email}
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      {/* Tabs for Details */}
+      <Tabs defaultValue="details" className="w-full">
+        <TabsList className="grid w-full grid-cols-3 lg:w-auto lg:grid-cols-none">
+          <TabsTrigger value="details">Details</TabsTrigger>
+          <TabsTrigger value="sponsors">
+            Sponsors {sponsors.length > 0 && `(${sponsors.length})`}
+          </TabsTrigger>
+          <TabsTrigger value="auction">
+            Auction {auctionItems.length > 0 && `(${auctionItems.length})`}
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Details Tab */}
+        <TabsContent value="details" className="space-y-6">
+          {/* Description */}
+          {currentEvent.description && (
+            <Card>
+              <CardHeader>
+                <CardTitle>About This Event</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground whitespace-pre-wrap">
+                  {currentEvent.description}
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Venue Details */}
+          {(currentEvent.venue_name || currentEvent.venue_address) && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <MapPin className="h-5 w-5" />
+                  Venue
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {currentEvent.venue_name && (
+                  <p className="font-medium">{currentEvent.venue_name}</p>
+                )}
+                {currentEvent.venue_address && (
+                  <p className="text-muted-foreground">{currentEvent.venue_address}</p>
+                )}
+                {(currentEvent.venue_city ||
+                  currentEvent.venue_state ||
+                  currentEvent.venue_zip) && (
+                    <p className="text-muted-foreground">
+                      {[
+                        currentEvent.venue_city,
+                        currentEvent.venue_state,
+                        currentEvent.venue_zip,
+                      ]
+                        .filter(Boolean)
+                        .join(', ')}
+                    </p>
+                  )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Food Options */}
+          {currentEvent.food_options && currentEvent.food_options.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Menu Options</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2">
+                  {currentEvent.food_options.map((option) => (
+                    <Badge key={option.id} variant="secondary">
+                      {option.icon && <span className="mr-1">{option.icon}</span>}
+                      {option.name}
+                    </Badge>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Event Links */}
+          {currentEvent.links && currentEvent.links.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Links</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  {currentEvent.links.map((link) => (
+                    <a
+                      key={link.id}
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary block hover:underline"
+                    >
+                      {link.label || link.url}
+                    </a>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </TabsContent>
+
+        {/* Sponsors Tab */}
+        <TabsContent value="sponsors" className="space-y-4">
+          {sponsors.length === 0 ? (
+            <Card>
+              <CardContent className="flex flex-col items-center justify-center py-12">
+                <Heart className="text-muted-foreground mb-4 h-12 w-12" />
+                <p className="text-muted-foreground">No sponsors yet</p>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {sponsors.map((sponsor) => (
+                <Card key={sponsor.id}>
+                  <CardContent className="pt-6">
+                    <div className="flex items-center gap-4">
+                      {sponsor.logo_url ? (
+                        <img
+                          src={sponsor.logo_url}
+                          alt={sponsor.name}
+                          className="h-12 w-12 rounded object-contain"
+                        />
+                      ) : (
+                        <div className="bg-muted flex h-12 w-12 items-center justify-center rounded">
+                          <Heart className="text-muted-foreground h-6 w-6" />
+                        </div>
+                      )}
+                      <div>
+                        <p className="font-medium">{sponsor.name}</p>
+                        <Badge variant="outline" className="mt-1">
+                          {sponsor.sponsor_level || 'Sponsor'}
+                        </Badge>
+                      </div>
+                    </div>
+                    {sponsor.website_url && (
+                      <a
+                        href={sponsor.website_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary mt-3 block text-sm hover:underline"
+                      >
+                        Visit website
+                      </a>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+
+        {/* Auction Tab */}
+        <TabsContent value="auction" className="space-y-4">
+          {auctionItems.length === 0 ? (
+            <Card>
+              <CardContent className="flex flex-col items-center justify-center py-12">
+                <Gavel className="text-muted-foreground mb-4 h-12 w-12" />
+                <p className="text-muted-foreground">No auction items yet</p>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {auctionItems.map((item) => (
+                <Card key={item.id} className="overflow-hidden">
+                  {item.primary_image_url && (
+                    <div className="aspect-video overflow-hidden">
+                      <img
+                        src={item.primary_image_url}
+                        alt={item.title}
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                  )}
+                  <CardHeader>
+                    <CardTitle className="text-lg">{item.title}</CardTitle>
+                    <CardDescription>
+                      <Badge variant="secondary">{item.auction_type}</Badge>
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    {item.description && (
+                      <p className="text-muted-foreground mb-4 line-clamp-2 text-sm">
+                        {item.description}
+                      </p>
+                    )}
+                    <div className="flex justify-between text-sm">
+                      <span className="text-muted-foreground">Starting Bid</span>
+                      <span className="font-medium">
+                        {formatCurrency(item.starting_bid)}
+                      </span>
+                    </div>
+                    {item.donor_value && (
+                      <div className="flex justify-between text-sm">
+                        <span className="text-muted-foreground">Est. Value</span>
+                        <span className="font-medium">
+                          {formatCurrency(item.donor_value)}
+                        </span>
+                      </div>
+                    )}
+                    {item.donated_by && (
+                      <p className="text-muted-foreground mt-2 text-xs">
+                        Donated by {item.donated_by}
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/frontend/donor-pwa/src/hooks/use-event-context.ts
+++ b/frontend/donor-pwa/src/hooks/use-event-context.ts
@@ -1,0 +1,103 @@
+/**
+ * useEventContext Hook
+ * Manages event context state with query invalidation for the donor PWA
+ *
+ * Business Rules:
+ * - Donors see events they are registered for
+ * - Admin users see events they have admin access to
+ * - Changes to event selection navigate to that event's page
+ * - Invalidates TanStack Query cache on event change
+ */
+
+import {
+  useEventContextStore,
+  type EventContextOption,
+} from '@/stores/event-context-store'
+import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { useCallback, useEffect } from 'react'
+
+export interface UseEventContextReturn {
+  selectedEventId: string | null
+  selectedEventName: string
+  selectedEventSlug: string | null
+  availableEvents: EventContextOption[]
+  isLoading: boolean
+  error: string | null
+
+  // Actions
+  selectEvent: (event: EventContextOption) => void
+  setAvailableEvents: (events: EventContextOption[]) => void
+
+  // Helpers
+  hasEvents: boolean
+  eventCount: number
+}
+
+export function useEventContext(): UseEventContextReturn {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const {
+    selectedEventId,
+    selectedEventName,
+    selectedEventSlug,
+    availableEvents,
+    isLoading,
+    error,
+    setSelectedEvent,
+    setAvailableEvents: storeSetAvailableEvents,
+  } = useEventContextStore()
+
+  const hasEvents = availableEvents.length > 0
+  const eventCount = availableEvents.length
+
+  // Auto-select first event if none selected and events are available
+  useEffect(() => {
+    if (!selectedEventId && availableEvents.length > 0) {
+      const firstEvent = availableEvents[0]
+      setSelectedEvent(firstEvent.id, firstEvent.name, firstEvent.slug)
+    }
+  }, [selectedEventId, availableEvents, setSelectedEvent])
+
+  // Select event and navigate to it
+  const selectEvent = useCallback(
+    (event: EventContextOption) => {
+      // Update store
+      setSelectedEvent(event.id, event.name, event.slug)
+
+      // Invalidate queries to refetch with new event context
+      queryClient.invalidateQueries()
+
+      // Navigate to the event page
+      navigate({ to: '/events/$eventId', params: { eventId: event.id } })
+    },
+    [setSelectedEvent, queryClient, navigate]
+  )
+
+  const setAvailableEvents = useCallback(
+    (events: EventContextOption[]) => {
+      storeSetAvailableEvents(events)
+
+      // Auto-select first event if we have events and none selected
+      if (events.length > 0 && !selectedEventId) {
+        const firstEvent = events[0]
+        setSelectedEvent(firstEvent.id, firstEvent.name, firstEvent.slug)
+      }
+    },
+    [storeSetAvailableEvents, selectedEventId, setSelectedEvent]
+  )
+
+  return {
+    selectedEventId,
+    selectedEventName,
+    selectedEventSlug,
+    availableEvents,
+    isLoading,
+    error,
+    selectEvent,
+    setAvailableEvents,
+    hasEvents,
+    eventCount,
+  }
+}

--- a/frontend/donor-pwa/src/routes/_authenticated/events/$eventId/edit.tsx
+++ b/frontend/donor-pwa/src/routes/_authenticated/events/$eventId/edit.tsx
@@ -1,6 +1,14 @@
-import { EventEditPage } from '@/features/events/EventEditPage'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Navigate, useParams } from '@tanstack/react-router'
+
+/**
+ * Event Edit Route - Disabled for Donor PWA
+ * Redirects to view page - donors cannot edit events
+ */
+function RedirectToView() {
+  const { eventId } = useParams({ strict: false }) as { eventId: string }
+  return <Navigate to="/events/$eventId" params={{ eventId }} />
+}
 
 export const Route = createFileRoute('/_authenticated/events/$eventId/edit')({
-  component: EventEditPage,
+  component: RedirectToView,
 })

--- a/frontend/donor-pwa/src/routes/_authenticated/events/$eventId/index.tsx
+++ b/frontend/donor-pwa/src/routes/_authenticated/events/$eventId/index.tsx
@@ -1,6 +1,10 @@
-import { EventEditPage } from '@/features/events/EventEditPage'
+import { EventViewPage } from '@/features/events/EventViewPage'
 import { createFileRoute } from '@tanstack/react-router'
 
+/**
+ * Event View Route
+ * Read-only event view for donors - no editing
+ */
 export const Route = createFileRoute('/_authenticated/events/$eventId/')({
-  component: EventEditPage,
+  component: EventViewPage,
 })

--- a/frontend/donor-pwa/src/routes/_authenticated/events/create.tsx
+++ b/frontend/donor-pwa/src/routes/_authenticated/events/create.tsx
@@ -1,6 +1,9 @@
-import { EventCreatePage } from '@/features/events/EventCreatePage'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Navigate } from '@tanstack/react-router'
 
+/**
+ * Event Create Route - Disabled for Donor PWA
+ * Redirects to home - donors cannot create events
+ */
 export const Route = createFileRoute('/_authenticated/events/create')({
-  component: EventCreatePage,
+  component: () => <Navigate to="/home" />,
 })

--- a/frontend/donor-pwa/src/routes/_authenticated/events/index.tsx
+++ b/frontend/donor-pwa/src/routes/_authenticated/events/index.tsx
@@ -1,6 +1,26 @@
-import { EventListPage } from '@/features/events/EventListPage'
-import { createFileRoute } from '@tanstack/react-router'
+import { useEventContext } from '@/hooks/use-event-context'
+import { createFileRoute, Navigate } from '@tanstack/react-router'
+
+/**
+ * Events Index Route
+ * Redirects to the selected event - no event list in donor PWA
+ */
+function EventsIndexPage() {
+  const { selectedEventId, hasEvents } = useEventContext()
+
+  // Redirect to selected event
+  if (selectedEventId) {
+    return <Navigate to="/events/$eventId" params={{ eventId: selectedEventId }} />
+  }
+
+  // No events - redirect to home
+  if (!hasEvents) {
+    return <Navigate to="/home" />
+  }
+
+  return null
+}
 
 export const Route = createFileRoute('/_authenticated/events/')({
-  component: EventListPage,
+  component: EventsIndexPage,
 })

--- a/frontend/donor-pwa/src/routes/_authenticated/home.tsx
+++ b/frontend/donor-pwa/src/routes/_authenticated/home.tsx
@@ -1,72 +1,41 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { createFileRoute } from '@tanstack/react-router'
-import { Calendar, Heart, Users } from 'lucide-react'
+import { useEventContext } from '@/hooks/use-event-context'
+import { createFileRoute, Navigate } from '@tanstack/react-router'
 
 /**
  * Donor PWA Home Page
- * Simple welcome page for donors with quick links
+ * Redirects to the selected event or shows a message if no events
  */
 function DonorHomePage() {
+  const { selectedEventId, hasEvents } = useEventContext()
+
+  // If user has a selected event, redirect to it
+  if (selectedEventId) {
+    return <Navigate to="/events/$eventId" params={{ eventId: selectedEventId }} />
+  }
+
+  // No events registered - show helpful message
+  if (!hasEvents) {
+    return (
+      <div className="container mx-auto space-y-6 px-4 py-6">
+        <div className="text-center py-12">
+          <h1 className="text-3xl font-bold mb-4">Welcome to Augeo</h1>
+          <p className="text-muted-foreground mb-8">
+            You haven't registered for any events yet.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Browse events and register to get started.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // Loading state while events are being fetched
   return (
     <div className="container mx-auto space-y-6 px-4 py-6">
-      <div>
-        <h1 className="text-3xl font-bold">Welcome to Augeo</h1>
-        <p className="text-muted-foreground mt-2">
-          Discover events, register, and support nonprofit organizations
-        </p>
-      </div>
-
-      <div className="grid gap-6 md:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Calendar className="h-5 w-5 text-primary" />
-              <CardTitle>Browse Events</CardTitle>
-            </div>
-            <CardDescription>
-              Find upcoming fundraising events and galas
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <a href="/events" className="text-primary hover:underline">
-              View all events →
-            </a>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Heart className="h-5 w-5 text-primary" />
-              <CardTitle>My Registrations</CardTitle>
-            </div>
-            <CardDescription>
-              View your upcoming event registrations
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <a href="/registrations" className="text-primary hover:underline">
-              View registrations →
-            </a>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Users className="h-5 w-5 text-primary" />
-              <CardTitle>Organizations</CardTitle>
-            </div>
-            <CardDescription>
-              Explore nonprofit organizations
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <a href="/npos" className="text-primary hover:underline">
-              Browse organizations →
-            </a>
-          </CardContent>
-        </Card>
+      <div className="text-center py-12">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+        <p className="text-muted-foreground">Loading your events...</p>
       </div>
     </div>
   )

--- a/frontend/donor-pwa/src/routes/_authenticated/npos/index.tsx
+++ b/frontend/donor-pwa/src/routes/_authenticated/npos/index.tsx
@@ -1,6 +1,9 @@
-import NpoListPage from '@/pages/npo/list-npo'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Navigate } from '@tanstack/react-router'
 
+/**
+ * NPO List Route - Disabled for Donor PWA
+ * Redirects to home - donors view events, not NPOs directly
+ */
 export const Route = createFileRoute('/_authenticated/npos/')({
-  component: NpoListPage,
+  component: () => <Navigate to="/home" />,
 })

--- a/frontend/donor-pwa/src/routes/_authenticated/registrations.tsx
+++ b/frontend/donor-pwa/src/routes/_authenticated/registrations.tsx
@@ -1,22 +1,10 @@
 /**
- * User Registrations Route
- * Displays user's event registrations (Phase 8 - deferred)
- * Placeholder for future implementation
+ * User Registrations Route - Disabled for Donor PWA
+ * Users select events from dropdown, not from registrations list
  */
 
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Navigate } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_authenticated/registrations')({
-  component: RegistrationsPage,
+  component: () => <Navigate to="/home" />,
 })
-
-function RegistrationsPage() {
-  return (
-    <div className="container mx-auto py-8">
-      <h1 className="text-2xl font-bold mb-4">My Registrations</h1>
-      <p className="text-muted-foreground">
-        This page will show your event registrations (Phase 8 - coming soon)
-      </p>
-    </div>
-  )
-}

--- a/frontend/donor-pwa/src/stores/event-context-store.ts
+++ b/frontend/donor-pwa/src/stores/event-context-store.ts
@@ -1,0 +1,104 @@
+/**
+ * Event Context Zustand Store
+ * Manages the currently selected event context for the donor PWA
+ *
+ * Business Rules:
+ * - Donors see only events they are registered for
+ * - Users with admin access see events they have admin access to
+ * - Selection persists across sessions via localStorage
+ * - Cleared on logout
+ */
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export interface EventContextOption {
+  id: string
+  name: string
+  slug: string
+  event_date?: string | null
+  npo_name?: string | null
+  logo_url?: string | null
+  has_admin_access?: boolean // True if user is admin/staff for this event
+}
+
+interface EventContextState {
+  // Currently selected event
+  selectedEventId: string | null
+  selectedEventName: string
+  selectedEventSlug: string | null
+
+  // Available event options for current user (populated on login)
+  availableEvents: EventContextOption[]
+
+  // Loading state
+  isLoading: boolean
+  error: string | null
+
+  // Actions
+  setSelectedEvent: (eventId: string | null, eventName: string, eventSlug: string | null) => void
+  setAvailableEvents: (events: EventContextOption[]) => void
+  setLoading: (loading: boolean) => void
+  setError: (error: string | null) => void
+  reset: () => void
+
+  // Helper getters
+  getSelectedEventId: () => string | null
+  getSelectedEventSlug: () => string | null
+}
+
+export const useEventContextStore = create<EventContextState>()(
+  persist(
+    (set, get) => ({
+      // Initial state
+      selectedEventId: null,
+      selectedEventName: 'Select Event',
+      selectedEventSlug: null,
+      availableEvents: [],
+      isLoading: false,
+      error: null,
+
+      // Setters
+      setSelectedEvent: (eventId, eventName, eventSlug) =>
+        set({
+          selectedEventId: eventId,
+          selectedEventName: eventName,
+          selectedEventSlug: eventSlug,
+          error: null,
+        }),
+
+      setAvailableEvents: (events) => set({ availableEvents: events }),
+
+      setLoading: (loading) => set({ isLoading: loading }),
+
+      setError: (error) => set({ error }),
+
+      reset: () =>
+        set({
+          selectedEventId: null,
+          selectedEventName: 'Select Event',
+          selectedEventSlug: null,
+          availableEvents: [],
+          isLoading: false,
+          error: null,
+        }),
+
+      // Getters
+      getSelectedEventId: (): string | null => {
+        return get().selectedEventId
+      },
+
+      getSelectedEventSlug: (): string | null => {
+        return get().selectedEventSlug
+      },
+    }),
+    {
+      name: 'augeo-event-context-storage',
+      partialize: (state) => ({
+        selectedEventId: state.selectedEventId,
+        selectedEventName: state.selectedEventName,
+        selectedEventSlug: state.selectedEventSlug,
+      }),
+    }
+  )
+)


### PR DESCRIPTION
## Summary

This PR restructures the donor PWA to be event-centric rather than NPO-centric, with read-only views appropriate for donors.

## Changes

### New Files
- `stores/event-context-store.ts` - Zustand store for selected event state (persisted to localStorage)
- `hooks/use-event-context.ts` - Hook for event selection with auto-navigation
- `components/layout/EventSelector.tsx` - Dropdown showing user's registered/admin events
- `features/events/EventViewPage.tsx` - Read-only event view with sponsors and auction items

### Modified Files
- `app-sidebar.tsx` - Replaced NpoSelector with EventSelector, simplified nav to Profile/Settings only
- `authenticated-layout.tsx` - Fetches user's event registrations and admin events instead of NPOs
- Route files updated with redirects to remove disabled functionality

## Behavior Changes

1. **Event Dropdown**: The sidebar now shows an event selector populated with:
   - Events the user is registered for
   - Events the user has admin access to (marked with shield icon)

2. **Auto-redirect**: On login, users are automatically redirected to their first available event

3. **Read-only Views**: Event pages display details, sponsors, and auction items without edit capabilities

4. **Removed Pages**:
   - Events list page (redirects to selected event)
   - Event create/edit pages (redirects to home/view)
   - NPO list page (redirects to home)
   - Registrations page (redirects to home)

## Testing

- [ ] Login as a donor with event registrations
- [ ] Verify event selector shows registered events
- [ ] Verify event view displays details, sponsors, and auction items
- [ ] Verify edit/create routes redirect appropriately
- [ ] Verify admin events show shield icon in selector