### PR TITLE
fix: iOS PWA nav bar height, safe area toasts, and notification thumbnails

### DIFF
--- a/backend/app/services/auction_bid_service.py
+++ b/backend/app/services/auction_bid_service.py
@@ -22,7 +22,7 @@ from app.models.auction_bid import (
     PaddleRaiseContribution,
     TransactionStatus,
 )
-from app.models.auction_item import AuctionItem, AuctionType
+from app.models.auction_item import AuctionItem, AuctionItemMedia, AuctionType
 from app.models.event import Event
 from app.models.event_registration import EventRegistration
 from app.models.notification import NotificationPriorityEnum, NotificationTypeEnum
@@ -257,6 +257,18 @@ class AuctionBidService:
         amount_str = f"${new_bid_amount:,.2f}" if new_bid_amount else "a higher amount"
         old_amount_str = f"${previous_bid.bid_amount:,.2f}"
 
+        # Fetch primary image for thumbnail
+        media_result = await self.db.execute(
+            select(AuctionItemMedia.file_path)
+            .where(
+                AuctionItemMedia.auction_item_id == item.id,
+                AuctionItemMedia.media_type == "image",
+            )
+            .order_by(AuctionItemMedia.display_order)
+            .limit(1)
+        )
+        image_url = media_result.scalar_one_or_none()
+
         async with self.db.begin_nested():
             await NotificationService.create_notification(
                 db=self.db,
@@ -271,9 +283,11 @@ class AuctionBidService:
                 ),
                 data={
                     "item_id": str(item.id),
+                    "item_title": item.title,
                     "deep_link": f"/events/{event_slug}?item={item.id}",
                     "animation_type": "flash",
                     "bid_amount": str(new_bid_amount) if new_bid_amount else None,
+                    **({"image_url": image_url} if image_url else {}),
                 },
                 sio=sio,
             )

--- a/backend/app/services/auction_bid_service.py
+++ b/backend/app/services/auction_bid_service.py
@@ -267,7 +267,29 @@ class AuctionBidService:
             .order_by(AuctionItemMedia.display_order)
             .limit(1)
         )
-        image_url = media_result.scalar_one_or_none()
+        image_url: str | None = None
+        raw_image_url = media_result.scalar_one_or_none()
+        if raw_image_url:
+            if raw_image_url.startswith("https://"):
+                try:
+                    from app.core.config import get_settings
+                    from app.services.auction_item_media_service import (
+                        AuctionItemMediaService,
+                    )
+
+                    _settings = get_settings()
+                    _media_svc = AuctionItemMediaService(_settings, self.db)
+                    container_path = f"{_settings.azure_storage_container_name}/"
+                    if container_path in raw_image_url:
+                        blob_path = raw_image_url.split(container_path, 1)[1]
+                        blob_path = blob_path.split("?", 1)[0]
+                        image_url = _media_svc._generate_blob_sas_url(blob_path, expiry_hours=24)
+                    else:
+                        image_url = raw_image_url
+                except Exception:
+                    image_url = raw_image_url
+            else:
+                image_url = raw_image_url
 
         async with self.db.begin_nested():
             await NotificationService.create_notification(

--- a/backend/app/tasks/notification_tasks.py
+++ b/backend/app/tasks/notification_tasks.py
@@ -171,7 +171,31 @@ async def _send_auction_closed_async(event_id: str) -> int:
                         .order_by(AuctionItemMedia.display_order)
                         .limit(1)
                     )
-                    item_image_url = media_result.scalar_one_or_none()
+                    item_image_url: str | None = None
+                    raw_image_url = media_result.scalar_one_or_none()
+                    if raw_image_url:
+                        if raw_image_url.startswith("https://"):
+                            try:
+                                from app.core.config import get_settings
+                                from app.services.auction_item_media_service import (
+                                    AuctionItemMediaService,
+                                )
+
+                                _settings = get_settings()
+                                _media_svc = AuctionItemMediaService(_settings, db)
+                                container_path = f"{_settings.azure_storage_container_name}/"
+                                if container_path in raw_image_url:
+                                    blob_path = raw_image_url.split(container_path, 1)[1]
+                                    blob_path = blob_path.split("?", 1)[0]
+                                    item_image_url = _media_svc._generate_blob_sas_url(
+                                        blob_path, expiry_hours=24
+                                    )
+                                else:
+                                    item_image_url = raw_image_url
+                            except Exception:
+                                item_image_url = raw_image_url
+                        else:
+                            item_image_url = raw_image_url
 
                     notification = await NotificationService.create_notification(
                         db=db,

--- a/backend/app/tasks/notification_tasks.py
+++ b/backend/app/tasks/notification_tasks.py
@@ -159,6 +159,20 @@ async def _send_auction_closed_async(event_id: str) -> int:
             for bid in winning_bids:
                 winner_user_ids.add(bid.user_id)
                 try:
+                    # Fetch primary image for thumbnail
+                    from app.models.auction_item import AuctionItemMedia
+
+                    media_result = await db.execute(
+                        select(AuctionItemMedia.file_path)
+                        .where(
+                            AuctionItemMedia.auction_item_id == bid.auction_item_id,
+                            AuctionItemMedia.media_type == "image",
+                        )
+                        .order_by(AuctionItemMedia.display_order)
+                        .limit(1)
+                    )
+                    item_image_url = media_result.scalar_one_or_none()
+
                     notification = await NotificationService.create_notification(
                         db=db,
                         event_id=event_uuid,
@@ -175,6 +189,7 @@ async def _send_auction_closed_async(event_id: str) -> int:
                             "deep_link": f"/events/{event_slug}?item={bid.auction_item_id}",
                             "animation_type": "confetti",
                             "bid_amount": str(bid.bid_amount),
+                            **({"image_url": item_image_url} if item_image_url else {}),
                         },
                         sio=sio,
                         dispatch_tasks=False,

--- a/frontend/donor-pwa/src/components/event-home/BottomTabNav.tsx
+++ b/frontend/donor-pwa/src/components/event-home/BottomTabNav.tsx
@@ -61,7 +61,7 @@ export function BottomTabNav({
             'linear-gradient(to top, rgb(0 0 0 / 0.16), rgb(0 0 0 / 0))',
         }}
       />
-      <div className='flex h-14 items-stretch'>
+      <div className='flex h-12 items-stretch'>
         {tabs.map((tab) => {
           const isActive = tab.id === activeTab
           const badgeCount = badges[tab.id] ?? 0

--- a/frontend/donor-pwa/src/components/layout/bottom-nav.tsx
+++ b/frontend/donor-pwa/src/components/layout/bottom-nav.tsx
@@ -52,7 +52,7 @@ export function BottomNav() {
           paddingBottom: 'var(--bottom-safe-area, 0px)',
         }}
       >
-        <div className='flex h-14 items-stretch'>
+        <div className='flex h-12 items-stretch'>
           <NavTab
             to='/settings'
             icon={UserCog}

--- a/frontend/donor-pwa/src/components/notifications/NotificationToastOverlay.tsx
+++ b/frontend/donor-pwa/src/components/notifications/NotificationToastOverlay.tsx
@@ -7,8 +7,8 @@
  * for dynamically-created elements outside of the React tree, so we use
  * inline styles + the keyframe animations defined in the global stylesheet).
  */
-import { useEffect } from 'react'
 import type { NotificationData } from '@/services/notification-service'
+import { useEffect } from 'react'
 
 const TOAST_DURATION = 5000
 const MAX_VISIBLE = 3
@@ -67,7 +67,7 @@ function ensureContainer() {
     containerEl = document.createElement('div')
     containerEl.id = 'notification-toast-overlay'
     containerEl.style.cssText =
-      'position:fixed;top:0;left:0;right:0;z-index:9999;pointer-events:none;display:flex;flex-direction:column;align-items:center;gap:8px;padding:12px 16px 0;'
+      'position:fixed;top:0;left:0;right:0;z-index:9999;pointer-events:none;display:flex;flex-direction:column;align-items:center;gap:8px;padding-top:calc(env(safe-area-inset-top, 0px) + 12px);padding-left:16px;padding-right:16px;padding-bottom:0;'
     document.body.appendChild(containerEl)
   }
 }

--- a/frontend/donor-pwa/src/styles/index.css
+++ b/frontend/donor-pwa/src/styles/index.css
@@ -71,15 +71,9 @@
   padding-top: env(safe-area-inset-top, 0px);
 }
 
-/* Bottom safe area: present in browser (gesture bar), absent in installed PWA */
+/* Bottom safe area: used in both browser and installed PWA (home indicator on iPhone) */
 :root {
   --bottom-safe-area: env(safe-area-inset-bottom, 0px);
-}
-
-@media (display-mode: standalone) {
-  :root {
-    --bottom-safe-area: 0px;
-  }
 }
 
 @utility no-scrollbar {


### PR DESCRIPTION
## Summary

Three bug fixes for the donor PWA on iOS when installed to the home screen:

### 1. Bottom nav bar too tall on iOS PWA
- Reduced `BottomTabNav` and `BottomNav` inner height from `h-14` (56px) to `h-12` (48px)
- Removed the `@media (display-mode: standalone)` override that zeroed out `--bottom-safe-area`. iOS PWA still has the home indicator (~34px) so `env(safe-area-inset-bottom)` must always be applied — this was the root cause of the nav appearing too tall on some devices

### 2. Toast notifications appearing behind iOS status bar
- Fixed `NotificationToastOverlay` (vanilla DOM) container top padding from a fixed `12px` to `calc(env(safe-area-inset-top, 0px) + 12px)`, so toasts always appear below the iOS status bar when running as a PWA (`viewport-fit=cover` extends content under it)
- The Sonner `<Toaster>` already had the correct `offset` prop; this was only missing in the custom notification overlay

### 3. Notification thumbnails not showing
- Outbid and item-won notifications were not including `image_url` in their `data` payload, so the frontend always fell back to the icon
- Fixed `_send_outbid_notification` in `auction_bid_service.py` to query `AuctionItemMedia` for the item's primary image and include it in the notification data
- Fixed the item-won winner loop in `notification_tasks.py` the same way