### PR TITLE
fix: restore update notification prompt and keep install banner visible

### DIFF
--- a/frontend/donor-pwa/vite.config.ts
+++ b/frontend/donor-pwa/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
       strategies: 'injectManifest',
       srcDir: 'src',
       filename: 'sw.ts',
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       devOptions: {
         enabled: true,
         type: 'module',

--- a/frontend/shared/src/pwa/install-prompt-banner.tsx
+++ b/frontend/shared/src/pwa/install-prompt-banner.tsx
@@ -38,16 +38,6 @@ export function InstallPromptBanner({
     return () => clearTimeout(showTimer)
   }, [canShow, showDelay])
 
-  // Auto-dismiss after 5 seconds of being visible
-  useEffect(() => {
-    if (!visible) return
-
-    const autoDismissTimer = setTimeout(() => {
-      setVisible(false)
-    }, 5000)
-
-    return () => clearTimeout(autoDismissTimer)
-  }, [visible])
 
   if (!visible || !canShow) return null
 


### PR DESCRIPTION
## Changes

### frontend/donor-pwa/vite.config.ts
- Change `registerType` from `'autoUpdate'` to `'prompt'`
- With `autoUpdate`, `needRefresh` was never `true` and the update banner never appeared
- Now users will see a "Refresh to update" banner when a new service worker is waiting

### frontend/shared/src/pwa/install-prompt-banner.tsx  
- Remove the 5-second auto-dismiss so users have time to read the Add to Home Screen instructions
- Users can still dismiss manually via the X button; the 7-day cooldown still applies

### Backend (already deployed)
- VAPID keys have been configured on Azure Container Apps (api, worker, beat)
- Push notifications should now work in production