### PR TITLE
feat/fix eagerly load userrole in social auth to fix ad

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1207,7 +1207,55 @@ async def apple_form_post_redirect(
         )
         result = await db.execute(stmt)
         attempt = result.scalar_one_or_none()
-        if attempt and attempt.app_context == "admin":
+        if attempt and attempt.app_context == "admin_pwa":
+            frontend_url = settings.frontend_admin_url
+
+    if error:
+        return RedirectResponse(
+            url=f"{frontend_url}/social-callback?error={error}",
+            status_code=302,
+        )
+
+    return RedirectResponse(
+        url=f"{frontend_url}/social-callback?code={code}&state={state}",
+        status_code=302,
+    )
+
+
+@router.get(
+    "/social/facebook/callback",
+    status_code=status.HTTP_302_FOUND,
+    include_in_schema=False,
+)
+async def facebook_redirect_callback(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    """Receive Facebook's redirect callback and route to the correct frontend SPA.
+
+    Facebook may only have one registered redirect URI in the Developer Console.
+    This backend relay acts as that registered URI so Facebook always lands here,
+    and then routes the browser to the correct frontend (admin or donor) based on
+    the app_context stored in the auth attempt identified by the state token.
+    """
+    from app.models.social_auth_attempt import SocialAuthAttempt
+
+    code = request.query_params.get("code", "")
+    state = request.query_params.get("state", "")
+    error = request.query_params.get("error", "")
+
+    settings = get_settings()
+
+    # Determine the correct frontend based on app_context stored in the attempt.
+    # Fall back to donor URL if the attempt can't be found (e.g. already expired).
+    frontend_url = settings.frontend_donor_url
+    if state:
+        stmt = select(SocialAuthAttempt).where(
+            SocialAuthAttempt.state_token == state,
+        )
+        result = await db.execute(stmt)
+        attempt = result.scalar_one_or_none()
+        if attempt and attempt.app_context == "admin_pwa":
             frontend_url = settings.frontend_admin_url
 
     if error:

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1343,7 +1343,7 @@ async def complete_admin_step_up(
         result = await SocialAuthService.complete_admin_step_up(
             db=db,
             attempt_id=step_up_data.attempt_id,
-            step_up_token=step_up_data.step_up_token,
+            password=step_up_data.password,
         )
         await db.commit()
         return result

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1180,21 +1180,35 @@ async def start_social_auth(
 )
 async def apple_form_post_redirect(
     request: Request,
+    db: AsyncSession = Depends(get_db),
 ) -> RedirectResponse:
     """Receive Apple's form_post callback and redirect to the frontend SPA.
 
     Apple POSTs code + state as form data when response_mode=form_post is used.
-    This endpoint extracts those values and sends the browser to the frontend
-    /social-callback route as a GET with query params, where existing JS handles
-    the code exchange.
+    This endpoint extracts those values and sends the browser to the correct
+    frontend /social-callback route (admin or donor) based on the app_context
+    stored in the auth attempt identified by the state token.
     """
+    from app.models.social_auth_attempt import SocialAuthAttempt
+
     form = await request.form()
     code = form.get("code", "")
     state = form.get("state", "")
     error = form.get("error", "")
 
     settings = get_settings()
+
+    # Determine the correct frontend based on app_context stored in the attempt.
+    # Fall back to donor URL if the attempt can't be found (e.g. already expired).
     frontend_url = settings.frontend_donor_url
+    if state:
+        stmt = select(SocialAuthAttempt).where(
+            SocialAuthAttempt.state_token == state,
+        )
+        result = await db.execute(stmt)
+        attempt = result.scalar_one_or_none()
+        if attempt and attempt.app_context == "admin":
+            frontend_url = settings.frontend_admin_url
 
     if error:
         return RedirectResponse(

--- a/backend/app/schemas/social_auth.py
+++ b/backend/app/schemas/social_auth.py
@@ -122,7 +122,7 @@ class AdminStepUpRequest(BaseModel):
     """Request to complete admin step-up verification."""
 
     attempt_id: uuid.UUID
-    step_up_token: str
+    password: str
 
 
 class SocialAuthErrorResponse(BaseModel):

--- a/backend/app/services/social_auth_service.py
+++ b/backend/app/services/social_auth_service.py
@@ -426,28 +426,29 @@ class SocialAuthService:
         cls,
         db: AsyncSession,
         attempt_id: uuid.UUID,
-        step_up_token: str,
+        password: str,
     ) -> SocialAuthSuccessResponse:
-        """Complete admin step-up verification."""
+        """Complete admin step-up verification by confirming the user's password."""
         stmt = select(AdminStepUpChallenge).where(
             AdminStepUpChallenge.attempt_id == attempt_id,
-            AdminStepUpChallenge.step_up_token == step_up_token,
             AdminStepUpChallenge.status == "pending",
         )
         result = await db.execute(stmt)
         challenge = result.scalar_one_or_none()
         if not challenge:
-            raise ValueError("Invalid step-up token")
+            raise ValueError("Invalid step-up challenge")
         if challenge.expires_at < datetime.now(UTC):
             challenge.status = "expired"
             raise ValueError("Step-up challenge has expired")
 
-        challenge.status = "satisfied"
-        challenge.completed_at = datetime.now(UTC)
-
         user = await cls._get_user_by_id(db, challenge.user_id)
         if not user:
             raise ValueError("User not found")
+        if not user.verify_password(password):
+            raise ValueError("Invalid password")
+
+        challenge.status = "satisfied"
+        challenge.completed_at = datetime.now(UTC)
 
         attempt = await cls._get_attempt_by_id(db, attempt_id)
         if not attempt:

--- a/backend/app/services/social_auth_service.py
+++ b/backend/app/services/social_auth_service.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 from app.core.config import get_settings
 from app.core.logging import get_logger
@@ -510,7 +511,7 @@ class SocialAuthService:
 
     @staticmethod
     async def _get_user_by_id(db: AsyncSession, user_id: uuid.UUID) -> User | None:
-        stmt = select(User).where(User.id == user_id)
+        stmt = select(User).options(joinedload(User.role)).where(User.id == user_id)
         result = await db.execute(stmt)
         return result.scalar_one_or_none()
 

--- a/backend/app/services/social_auth_service.py
+++ b/backend/app/services/social_auth_service.py
@@ -909,6 +909,13 @@ class SocialAuthService:
             # Override redirect_uri to backend relay — must match what's registered in Apple portal
             apple_callback_base = settings.social_auth_callback_base_url.rstrip("/")
             params["redirect_uri"] = f"{apple_callback_base}/auth/social/apple/redirect"
+        if provider == ProviderKey.FACEBOOK:
+            # Use backend relay URL — must match what's registered in Facebook Developer Console.
+            # Since the Facebook app may only have one valid redirect URI configured, using
+            # the backend relay lets us route to either frontend (admin or donor) based on
+            # the app_context stored in the auth attempt.
+            fb_callback_base = settings.social_auth_callback_base_url.rstrip("/")
+            params["redirect_uri"] = f"{fb_callback_base}/auth/social/facebook/callback"
         if provider in (ProviderKey.GOOGLE, ProviderKey.MICROSOFT):
             # Always show the account picker so users can choose which account to use.
             # Without this, both Google and Microsoft use a silently-cached session
@@ -1095,13 +1102,20 @@ class SocialAuthService:
 
         # --- Facebook: exchange code for access token, then fetch user info ---
         if provider == ProviderKey.FACEBOOK and client_id and client_secret:
+            # The redirect_uri in the token exchange must exactly match the one used in the
+            # authorization URL — which is the backend relay, not the frontend callback URL.
+            fb_settings = get_settings()
+            fb_redirect_uri = (
+                f"{fb_settings.social_auth_callback_base_url.rstrip('/')}"
+                "/auth/social/facebook/callback"
+            )
             async with httpx.AsyncClient(timeout=10.0) as http:
                 fb_token_resp = await http.get(
                     "https://graph.facebook.com/v18.0/oauth/access_token",
                     params={
                         "client_id": client_id,
                         "client_secret": client_secret,
-                        "redirect_uri": redirect_uri,
+                        "redirect_uri": fb_redirect_uri,
                         "code": code,
                     },
                 )

--- a/backend/app/services/social_auth_service.py
+++ b/backend/app/services/social_auth_service.py
@@ -908,8 +908,10 @@ class SocialAuthService:
             # Override redirect_uri to backend relay — must match what's registered in Apple portal
             apple_callback_base = settings.social_auth_callback_base_url.rstrip("/")
             params["redirect_uri"] = f"{apple_callback_base}/auth/social/apple/redirect"
-        if provider == ProviderKey.GOOGLE:
-            # Always show the account picker so users can choose which Google account to use
+        if provider in (ProviderKey.GOOGLE, ProviderKey.MICROSOFT):
+            # Always show the account picker so users can choose which account to use.
+            # Without this, both Google and Microsoft use a silently-cached session
+            # instead of prompting — which can log the wrong account in.
             params["prompt"] = "select_account"
         return f"{auth_base}?{urllib.parse.urlencode(params)}"
 

--- a/backend/app/tests/contract/test_social_auth_admin_step_up.py
+++ b/backend/app/tests/contract/test_social_auth_admin_step_up.py
@@ -25,7 +25,7 @@ async def test_admin_step_up_invalid_attempt_returns_400(
         "/api/v1/auth/social/admin-step-up",
         json={
             "attempt_id": "00000000-0000-0000-0000-000000000000",
-            "step_up_token": "admin_password",
+            "password": "admin_password",
         },
     )
     assert response.status_code in (400, 401)
@@ -35,7 +35,7 @@ async def test_admin_step_up_invalid_attempt_returns_400(
 async def test_admin_step_up_missing_password_returns_422(
     async_client: AsyncClient,
 ) -> None:
-    """Verify admin step-up without step_up_token returns 422."""
+    """Verify admin step-up without password returns 422."""
     response = await async_client.post(
         "/api/v1/auth/social/admin-step-up",
         json={"attempt_id": "00000000-0000-0000-0000-000000000000"},
@@ -52,7 +52,7 @@ async def test_admin_step_up_response_shape(
         "/api/v1/auth/social/admin-step-up",
         json={
             "attempt_id": "00000000-0000-0000-0000-000000000000",
-            "step_up_token": "admin_password",
+            "password": "admin_password",
         },
     )
     data = response.json()

--- a/backend/app/tests/integration/test_social_auth_flow.py
+++ b/backend/app/tests/integration/test_social_auth_flow.py
@@ -42,7 +42,7 @@ async def test_social_auth_admin_step_up_invalid(async_client: AsyncClient) -> N
         "/api/v1/auth/social/admin-step-up",
         json={
             "attempt_id": "00000000-0000-0000-0000-000000000000",
-            "step_up_token": "invalid_token",
+            "password": "invalid_password",
         },
     )
     assert response.status_code in (401, 400)

--- a/backend/app/tests/unit/test_social_auth_url_building.py
+++ b/backend/app/tests/unit/test_social_auth_url_building.py
@@ -6,23 +6,24 @@ from app.schemas.social_auth import ProviderKey
 from app.services.social_auth_service import SocialAuthService
 
 
-def test_google_auth_url_includes_select_account_prompt() -> None:
-    """Google authorization URL must include prompt=select_account."""
-    url = SocialAuthService._build_authorization_url(
-        provider=ProviderKey.GOOGLE,
-        state="test_state",
-        redirect_uri="https://example.com/callback",
-        pkce_verifier="verifier",
-    )
-    params = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(url).query))
-    assert params.get("prompt") == "select_account", (
-        "Google OAuth URL must include prompt=select_account so users see the account picker"
-    )
+def test_google_and_microsoft_auth_url_includes_select_account_prompt() -> None:
+    """Google and Microsoft authorization URLs must include prompt=select_account."""
+    for provider in (ProviderKey.GOOGLE, ProviderKey.MICROSOFT):
+        url = SocialAuthService._build_authorization_url(
+            provider=provider,
+            state="test_state",
+            redirect_uri="https://example.com/callback",
+            pkce_verifier="verifier",
+        )
+        params = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(url).query))
+        assert params.get("prompt") == "select_account", (
+            f"{provider} OAuth URL must include prompt=select_account so users see the account picker"
+        )
 
 
-def test_non_google_providers_do_not_include_prompt() -> None:
-    """Non-Google providers should not have a prompt parameter injected."""
-    for provider in (ProviderKey.FACEBOOK, ProviderKey.MICROSOFT):
+def test_non_google_microsoft_providers_do_not_include_prompt() -> None:
+    """Providers other than Google/Microsoft should not have a prompt parameter injected."""
+    for provider in (ProviderKey.FACEBOOK,):
         url = SocialAuthService._build_authorization_url(
             provider=provider,
             state="test_state",

--- a/frontend/fundrbolt-admin/src/components/layout/authenticated-layout.tsx
+++ b/frontend/fundrbolt-admin/src/components/layout/authenticated-layout.tsx
@@ -70,7 +70,7 @@ export function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
       <SkipToMain />
       <div className='flex min-h-svh flex-col'>
         <TopNavBar />
-        <main className='@container/content flex-1 p-4 sm:p-6'>
+        <main className='flex-1 p-4 sm:p-6'>
           {children ?? <Outlet />}
         </main>
         <LegalFooter />

--- a/frontend/fundrbolt-admin/src/components/layout/authenticated-layout.tsx
+++ b/frontend/fundrbolt-admin/src/components/layout/authenticated-layout.tsx
@@ -1,14 +1,14 @@
-import { useEffect } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { Outlet } from '@tanstack/react-router'
-import type { NPOContextOption } from '@/stores/npo-context-store'
-import apiClient from '@/lib/axios'
-import { SearchProvider } from '@/context/search-provider'
-import { useAuth } from '@/hooks/use-auth'
-import { useNpoContext } from '@/hooks/use-npo-context'
 import { TopNavBar } from '@/components/layout/top-nav-bar'
 import { LegalFooter } from '@/components/legal/legal-footer'
 import { SkipToMain } from '@/components/skip-to-main'
+import { SearchProvider } from '@/context/search-provider'
+import { useAuth } from '@/hooks/use-auth'
+import { useNpoContext } from '@/hooks/use-npo-context'
+import apiClient from '@/lib/axios'
+import type { NPOContextOption } from '@/stores/npo-context-store'
+import { useQuery } from '@tanstack/react-query'
+import { Outlet } from '@tanstack/react-router'
+import { useEffect } from 'react'
 
 type AuthenticatedLayoutProps = {
   children?: React.ReactNode

--- a/frontend/fundrbolt-admin/src/components/layout/top-nav-bar.tsx
+++ b/frontend/fundrbolt-admin/src/components/layout/top-nav-bar.tsx
@@ -306,10 +306,18 @@ function EventChip() {
   const href = useLocation({ select: (l) => l.href })
   const { availableEvents, selectedEventId } = useEventContext()
   const { availableNpos } = useNpoContext()
-  const selectedEvent = availableEvents.find((e) => e.id === selectedEventId)
 
-  // Only show when inside an event route
-  if (!href.includes('/events/') || !selectedEvent) return null
+  // Extract event ID/slug from the URL path (e.g. /events/abc-123/auctioneer/)
+  const urlEventId = href.match(/\/events\/([^/]+)/)?.[1] ?? null
+
+  // Prefer the event the user is currently viewing (from URL), fall back to selected
+  const effectiveEventId = urlEventId || selectedEventId
+  const selectedEvent = availableEvents.find(
+    (e) => e.id === effectiveEventId || e.slug === effectiveEventId
+  )
+
+  // Only show when inside an event route with a known event
+  if (!urlEventId || !selectedEvent) return null
 
   const logoUrl = selectedEvent.logo_url ?? null
   const selectedNpo = availableNpos.find(

--- a/frontend/fundrbolt-admin/src/components/layout/top-nav-bar.tsx
+++ b/frontend/fundrbolt-admin/src/components/layout/top-nav-bar.tsx
@@ -5,25 +5,8 @@
  * Desktop: Logo | Nav dropdowns | Search | Profile
  * Mobile:  Logo | Hamburger (sheet) | Search | Profile
  */
-import { useState } from 'react'
-import { Link, useLocation, useNavigate } from '@tanstack/react-router'
-import LogoWhiteGoldPng from '@fundrbolt/shared/assets/logos/fundrbolt-logo-white-gold.png'
-import {
-  BarChart3,
-  Calendar,
-  CreditCard,
-  Gavel,
-  Heart,
-  Menu,
-  SearchIcon,
-  Settings,
-  Users,
-} from 'lucide-react'
-import { cn } from '@/lib/utils'
-import { useSearch } from '@/context/search-provider'
-import { useEventContext } from '@/hooks/use-event-context'
-import { useNpoContext } from '@/hooks/use-npo-context'
-import { useRoleBasedNav } from '@/hooks/use-role-based-nav'
+import { CommandMenu } from '@/components/command-menu'
+import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Button } from '@/components/ui/button'
 import { InitialAvatar } from '@/components/ui/initial-avatar'
 import {
@@ -47,8 +30,25 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { CommandMenu } from '@/components/command-menu'
-import { ProfileDropdown } from '@/components/profile-dropdown'
+import { useSearch } from '@/context/search-provider'
+import { useEventContext } from '@/hooks/use-event-context'
+import { useNpoContext } from '@/hooks/use-npo-context'
+import { useRoleBasedNav } from '@/hooks/use-role-based-nav'
+import { cn } from '@/lib/utils'
+import LogoWhiteGoldPng from '@fundrbolt/shared/assets/logos/fundrbolt-logo-white-gold.png'
+import { Link, useLocation, useNavigate } from '@tanstack/react-router'
+import {
+  BarChart3,
+  Calendar,
+  CreditCard,
+  Gavel,
+  Heart,
+  Menu,
+  SearchIcon,
+  Settings,
+  Users,
+} from 'lucide-react'
+import { useState } from 'react'
 import { iconMap } from './icon-map'
 
 /** Map nav group titles to lucide icons for the trigger buttons */
@@ -100,16 +100,16 @@ function DesktopNav() {
     })),
     ...(donateNowNavGroup
       ? [
-          {
-            title: donateNowNavGroup.title,
-            items: donateNowNavGroup.items.map((i) => ({
-              title: i.title,
-              href: i.href,
-              icon: i.icon,
-              badge: i.badge,
-            })),
-          },
-        ]
+        {
+          title: donateNowNavGroup.title,
+          items: donateNowNavGroup.items.map((i) => ({
+            title: i.title,
+            href: i.href,
+            icon: i.icon,
+            badge: i.badge,
+          })),
+        },
+      ]
       : []),
     adminGroup,
   ]
@@ -143,7 +143,7 @@ function DesktopNav() {
                             'flex flex-col items-center gap-1 rounded-sm px-3 py-2.5 text-sm transition-colors',
                             'hover:bg-accent hover:text-accent-foreground',
                             isActive &&
-                              'bg-accent/50 text-accent-foreground font-medium'
+                            'bg-accent/50 text-accent-foreground font-medium'
                           )}
                         >
                           {Icon && (
@@ -190,16 +190,16 @@ function MobileNav() {
     })),
     ...(donateNowNavGroup
       ? [
-          {
-            title: donateNowNavGroup.title,
-            items: donateNowNavGroup.items.map((i) => ({
-              title: i.title,
-              href: i.href,
-              icon: i.icon,
-              badge: i.badge,
-            })),
-          },
-        ]
+        {
+          title: donateNowNavGroup.title,
+          items: donateNowNavGroup.items.map((i) => ({
+            title: i.title,
+            href: i.href,
+            icon: i.icon,
+            badge: i.badge,
+          })),
+        },
+      ]
       : []),
     {
       title: 'Admin',
@@ -259,7 +259,7 @@ function MobileNav() {
                             'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors',
                             'hover:bg-accent hover:text-accent-foreground',
                             isActive &&
-                              'bg-accent text-accent-foreground font-medium'
+                            'bg-accent text-accent-foreground font-medium'
                           )}
                         >
                           {Icon && (
@@ -329,7 +329,7 @@ function EventChip() {
     selectedEvent.npo_name,
     selectedEvent.status
       ? selectedEvent.status.charAt(0).toUpperCase() +
-        selectedEvent.status.slice(1)
+      selectedEvent.status.slice(1)
       : null,
   ]
     .filter(Boolean)

--- a/frontend/fundrbolt-admin/src/components/legal/legal-footer.tsx
+++ b/frontend/fundrbolt-admin/src/components/legal/legal-footer.tsx
@@ -32,7 +32,9 @@ export function LegalFooter() {
             Privacy Policy
           </Link>
         </nav>
-        <p className='text-muted-foreground/50 text-xs tabular-nums'>v{__APP_VERSION__}</p>
+        <p className='text-muted-foreground/50 text-xs tabular-nums'>
+          v{__APP_VERSION__}
+        </p>
       </div>
     </footer>
   )

--- a/frontend/fundrbolt-admin/src/components/legal/legal-footer.tsx
+++ b/frontend/fundrbolt-admin/src/components/legal/legal-footer.tsx
@@ -32,6 +32,7 @@ export function LegalFooter() {
             Privacy Policy
           </Link>
         </nav>
+        <p className='text-muted-foreground/50 text-xs tabular-nums'>v{__APP_VERSION__}</p>
       </div>
     </footer>
   )

--- a/frontend/fundrbolt-admin/src/components/profile-dropdown.tsx
+++ b/frontend/fundrbolt-admin/src/components/profile-dropdown.tsx
@@ -1,19 +1,5 @@
-import { useState } from 'react'
-import { Link } from '@tanstack/react-router'
-import {
-  Building2,
-  Calendar,
-  ChevronDown,
-  ChevronUp,
-  Clock,
-  LogOut,
-  Settings,
-} from 'lucide-react'
-import { useAuthStore } from '@/stores/auth-store'
-import { useDebugSpoofStore } from '@/stores/debug-spoof-store'
-import useDialogState from '@/hooks/use-dialog-state'
-import { useEventContext } from '@/hooks/use-event-context'
-import { useNpoContext } from '@/hooks/use-npo-context'
+import { DebugSpoofSheet } from '@/components/debug-spoof-sheet'
+import { SignOutDialog } from '@/components/sign-out-dialog'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import {
@@ -33,8 +19,22 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { InitialAvatar } from '@/components/ui/initial-avatar'
-import { DebugSpoofSheet } from '@/components/debug-spoof-sheet'
-import { SignOutDialog } from '@/components/sign-out-dialog'
+import useDialogState from '@/hooks/use-dialog-state'
+import { useEventContext } from '@/hooks/use-event-context'
+import { useNpoContext } from '@/hooks/use-npo-context'
+import { useAuthStore } from '@/stores/auth-store'
+import { useDebugSpoofStore } from '@/stores/debug-spoof-store'
+import { Link } from '@tanstack/react-router'
+import {
+  Building2,
+  Calendar,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  LogOut,
+  Settings,
+} from 'lucide-react'
+import { useState } from 'react'
 
 export function ProfileDropdown() {
   const [open, setOpen] = useDialogState()
@@ -76,8 +76,8 @@ export function ProfileDropdown() {
   const filteredEvents =
     shouldShowSearch && eventSearchQuery
       ? availableEvents.filter((event) =>
-          event.name.toLowerCase().includes(eventSearchQuery.toLowerCase())
-        )
+        event.name.toLowerCase().includes(eventSearchQuery.toLowerCase())
+      )
       : availableEvents
 
   return (

--- a/frontend/fundrbolt-admin/src/components/profile-dropdown.tsx
+++ b/frontend/fundrbolt-admin/src/components/profile-dropdown.tsx
@@ -1,6 +1,14 @@
 import { useState } from 'react'
 import { Link } from '@tanstack/react-router'
-import { Building2, Calendar, Clock, LogOut, Settings } from 'lucide-react'
+import {
+  Building2,
+  Calendar,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  LogOut,
+  Settings,
+} from 'lucide-react'
 import { useAuthStore } from '@/stores/auth-store'
 import { useDebugSpoofStore } from '@/stores/debug-spoof-store'
 import useDialogState from '@/hooks/use-dialog-state'
@@ -22,9 +30,6 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { InitialAvatar } from '@/components/ui/initial-avatar'
@@ -57,6 +62,8 @@ export function ProfileDropdown() {
   } = useNpoContext()
   const timeBaseSpoofMs = useDebugSpoofStore((state) => state.timeBaseSpoofMs)
   const [spoofSheetOpen, setSpoofSheetOpen] = useState(false)
+  const [npoListOpen, setNpoListOpen] = useState(false)
+  const [eventListOpen, setEventListOpen] = useState(false)
 
   const isSuperAdmin = user?.role === 'super_admin'
 
@@ -105,20 +112,28 @@ export function ProfileDropdown() {
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuLabel>Context</DropdownMenuLabel>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              <Building2 className='mr-2 size-4' />
-              <div className='flex min-w-0 flex-1 flex-col text-left'>
-                <span>NPO</span>
-                <span className='text-muted-foreground truncate text-xs font-normal'>
-                  {selectedNpoName}
-                </span>
-              </div>
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className='w-72 p-1'>
-              <DropdownMenuLabel className='text-muted-foreground text-xs'>
-                Organizations
-              </DropdownMenuLabel>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault()
+              setNpoListOpen((v) => !v)
+            }}
+            className='gap-2'
+          >
+            <Building2 className='mr-2 size-4 shrink-0' />
+            <div className='flex min-w-0 flex-1 flex-col text-left'>
+              <span>NPO</span>
+              <span className='text-muted-foreground truncate text-xs font-normal'>
+                {selectedNpoName}
+              </span>
+            </div>
+            {npoListOpen ? (
+              <ChevronUp className='size-4 shrink-0' />
+            ) : (
+              <ChevronDown className='size-4 shrink-0' />
+            )}
+          </DropdownMenuItem>
+          {npoListOpen && (
+            <div className='border-muted ml-4 border-l-2 pl-2'>
               {availableNpos.length === 0 ? (
                 <DropdownMenuItem disabled>
                   No organizations available
@@ -130,6 +145,7 @@ export function ProfileDropdown() {
                     disabled={!canChangeNpo && selectedNpoId !== npo.id}
                     onClick={() => {
                       selectNpo(npo.id, npo.name)
+                      setNpoListOpen(false)
                       setMenuOpen(false)
                     }}
                     className='gap-2 p-2'
@@ -161,19 +177,30 @@ export function ProfileDropdown() {
                   </DropdownMenuItem>
                 ))
               )}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              <Calendar className='mr-2 size-4' />
-              <div className='flex min-w-0 flex-1 flex-col text-left'>
-                <span>Event</span>
-                <span className='text-muted-foreground truncate text-xs font-normal'>
-                  {selectedEventName || 'Select Event'}
-                </span>
-              </div>
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className='w-80 p-0'>
+            </div>
+          )}
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault()
+              setEventListOpen((v) => !v)
+            }}
+            className='gap-2'
+          >
+            <Calendar className='mr-2 size-4 shrink-0' />
+            <div className='flex min-w-0 flex-1 flex-col text-left'>
+              <span>Event</span>
+              <span className='text-muted-foreground truncate text-xs font-normal'>
+                {selectedEventName || 'Select Event'}
+              </span>
+            </div>
+            {eventListOpen ? (
+              <ChevronUp className='size-4 shrink-0' />
+            ) : (
+              <ChevronDown className='size-4 shrink-0' />
+            )}
+          </DropdownMenuItem>
+          {eventListOpen && (
+            <div className='border-muted ml-4 border-l-2 pl-2'>
               {isEventsLoading ? (
                 <div className='px-3 py-2 text-sm'>Loading events...</div>
               ) : availableEvents.length === 0 ? (
@@ -279,8 +306,8 @@ export function ProfileDropdown() {
                   ))}
                 </>
               )}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
+            </div>
+          )}
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild>
             <Link to='/settings'>

--- a/frontend/fundrbolt-admin/src/components/reports/BidCardSizeDialog.tsx
+++ b/frontend/fundrbolt-admin/src/components/reports/BidCardSizeDialog.tsx
@@ -1,6 +1,13 @@
 /**
  * BidCardSizeDialog — select label size, configure options, and trigger bid card PDF download.
  */
+import { useState } from 'react'
+import {
+  type BidCardRequest,
+  type LabelSize,
+  LABEL_SIZE_OPTIONS,
+} from '@/services/reportService'
+import { Printer } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -13,13 +20,6 @@ import {
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
-import {
-  type BidCardRequest,
-  type LabelSize,
-  LABEL_SIZE_OPTIONS,
-} from '@/services/reportService'
-import { Printer } from 'lucide-react'
-import { useState } from 'react'
 
 interface BidCardSizeDialogProps {
   open: boolean
@@ -72,7 +72,10 @@ export function BidCardSizeDialog({
   const handleSizeChange = (size: LabelSize) => {
     setLabelSize(size)
     // Auto-set event logo default based on whether the new size is a tent
-    setOptions((prev) => ({ ...prev, showEventLogo: TENT_SIZES.includes(size) }))
+    setOptions((prev) => ({
+      ...prev,
+      showEventLogo: TENT_SIZES.includes(size),
+    }))
   }
 
   const count = selectedItemIds?.length ?? 0

--- a/frontend/fundrbolt-admin/src/components/ui/dropdown-menu.tsx
+++ b/frontend/fundrbolt-admin/src/components/ui/dropdown-menu.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@/lib/utils'
+import * as React from 'react'
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
-import * as React from 'react'
+import { cn } from '@/lib/utils'
 
 function DropdownMenu({
   ...props
@@ -242,10 +242,19 @@ function DropdownMenuSubContent({
 }
 
 export {
-  DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent,
-  DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuPortal, DropdownMenuRadioGroup,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 }

--- a/frontend/fundrbolt-admin/src/features/auctioneer/pages/AuctioneerDashboardPage.tsx
+++ b/frontend/fundrbolt-admin/src/features/auctioneer/pages/AuctioneerDashboardPage.tsx
@@ -1,5 +1,30 @@
-import { BidderAvatar } from '@/components/bidder-avatar'
-import { DataTableViewToggle } from '@/components/data-table/view-toggle'
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { auctioneerService } from '@/services/auctioneerService'
+import { reportService } from '@/services/reportService'
+import { getAuctioneerRunOfShow } from '@/services/runOfShowService'
+import {
+  ArrowUpDown,
+  CalendarClock,
+  CircleDollarSign,
+  Clock,
+  Coins,
+  Download,
+  Eye,
+  EyeOff,
+  FileText,
+  Filter,
+  Gavel,
+  HandCoins,
+  Image as ImageIcon,
+  Pin,
+  PinOff,
+  Target,
+  Timer,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { useViewPreference } from '@/hooks/use-view-preference'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -31,35 +56,10 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { BidderAvatar } from '@/components/bidder-avatar'
+import { DataTableViewToggle } from '@/components/data-table/view-toggle'
 import { useEventWorkspace } from '@/features/events/useEventWorkspace'
 import { RGAuctioneerTab } from '@/features/revenue-generators'
-import { useViewPreference } from '@/hooks/use-view-preference'
-import { auctioneerService } from '@/services/auctioneerService'
-import { reportService } from '@/services/reportService'
-import { getAuctioneerRunOfShow } from '@/services/runOfShowService'
-import { useQuery } from '@tanstack/react-query'
-import { useNavigate } from '@tanstack/react-router'
-import {
-  ArrowUpDown,
-  CalendarClock,
-  CircleDollarSign,
-  Clock,
-  Coins,
-  Download,
-  Eye,
-  EyeOff,
-  FileText,
-  Filter,
-  Gavel,
-  HandCoins,
-  Image as ImageIcon,
-  Pin,
-  PinOff,
-  Target,
-  Timer,
-} from 'lucide-react'
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import { EventMapCard } from '../components/EventMapCard'
 import { RosCountdownBadge } from '../components/RosCountdownBadge'
 import { RunOfShowCard } from '../components/RunOfShowCard'
@@ -408,8 +408,9 @@ export function AuctioneerDashboardPage({
       </div>
 
       <div
-        className={`bg-background/95 supports-[backdrop-filter]:bg-background/85 -mx-4 border-b px-4 py-2 backdrop-blur lg:-mx-6 lg:px-6 ${summaryPinned ? 'sticky top-14 z-20' : ''
-          }`}
+        className={`bg-background/95 supports-[backdrop-filter]:bg-background/85 -mx-4 border-b px-4 py-2 backdrop-blur lg:-mx-6 lg:px-6 ${
+          summaryPinned ? 'sticky top-14 z-20' : ''
+        }`}
       >
         <div className='relative'>
           <div className='grid min-w-0 auto-cols-auto grid-flow-col grid-rows-2 gap-1.5 overflow-x-auto pr-8 pb-0.5'>
@@ -608,10 +609,10 @@ export function AuctioneerDashboardPage({
                   value: fmtCurrency(paddleRaise.data?.total_pledged),
                   detail:
                     paddleRaise.data?.total_goal != null &&
-                      paddleRaise.data?.total_goal_progress_percent != null
+                    paddleRaise.data?.total_goal_progress_percent != null
                       ? `Goal ${fmtCurrency(
-                        paddleRaise.data.total_goal
-                      )} · ${paddleRaise.data.total_goal_progress_percent.toFixed(2)}% complete`
+                          paddleRaise.data.total_goal
+                        )} · ${paddleRaise.data.total_goal_progress_percent.toFixed(2)}% complete`
                       : undefined,
                 },
                 {
@@ -678,7 +679,7 @@ export function AuctioneerDashboardPage({
                           %
                         </p>
                         {level.goal_amount != null &&
-                          level.goal_progress_percent != null ? (
+                        level.goal_progress_percent != null ? (
                           <p className='text-muted-foreground text-xs'>
                             Goal {fmtCurrency(level.goal_amount)} ·{' '}
                             {level.goal_progress_percent.toFixed(2)}% complete
@@ -745,11 +746,11 @@ export function AuctioneerDashboardPage({
                         onValueChange={(value) =>
                           setPaddleDonationsSort(
                             value as
-                            | 'newest'
-                            | 'oldest'
-                            | 'amount_desc'
-                            | 'amount_asc'
-                            | 'bidder_asc'
+                              | 'newest'
+                              | 'oldest'
+                              | 'amount_desc'
+                              | 'amount_asc'
+                              | 'bidder_asc'
                           )
                         }
                       >
@@ -894,18 +895,19 @@ function CompactStatusChip({
 }) {
   return (
     <div
-      className={`bg-muted/70 flex min-h-9 items-center gap-2 rounded-md border px-2.5 py-1 text-xs${onClick
+      className={`bg-muted/70 flex min-h-9 items-center gap-2 rounded-md border px-2.5 py-1 text-xs${
+        onClick
           ? 'hover:bg-muted hover:border-foreground/20 cursor-pointer transition-colors'
           : ''
-        }`}
+      }`}
       onClick={onClick}
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
       onKeyDown={
         onClick
           ? (e) => {
-            if (e.key === 'Enter' || e.key === ' ') onClick()
-          }
+              if (e.key === 'Enter' || e.key === ' ') onClick()
+            }
           : undefined
       }
     >
@@ -940,23 +942,23 @@ function ItemGallerySection({
   title: string
   subtitle: string
   items:
-  | Array<{
-    id: string
-    bid_number: number | null
-    title: string
-    current_bid_amount: number | null
-    bid_count: number
-    bidder_count: number
-    primary_image_url: string | null
-    donor_value: number | null
-    auction_type: string
-    has_commission: boolean
-    has_bounty: boolean
-    commission_percent: number | null
-    flat_fee: number | null
-  }>
-  | null
-  | undefined
+    | Array<{
+        id: string
+        bid_number: number | null
+        title: string
+        current_bid_amount: number | null
+        bid_count: number
+        bidder_count: number
+        primary_image_url: string | null
+        donor_value: number | null
+        auction_type: string
+        has_commission: boolean
+        has_bounty: boolean
+        commission_percent: number | null
+        flat_fee: number | null
+      }>
+    | null
+    | undefined
   isLoading: boolean
   error: unknown
   totalItems: number
@@ -1510,11 +1512,11 @@ function BidderTotalsCard({
             onValueChange={(value) =>
               setSortValue(
                 value as
-                | 'amount_desc'
-                | 'amount_asc'
-                | 'count_desc'
-                | 'count_asc'
-                | 'bidder_asc'
+                  | 'amount_desc'
+                  | 'amount_asc'
+                  | 'count_desc'
+                  | 'count_asc'
+                  | 'bidder_asc'
               )
             }
           >

--- a/frontend/fundrbolt-admin/src/features/auth/auth-layout.tsx
+++ b/frontend/fundrbolt-admin/src/features/auth/auth-layout.tsx
@@ -1,5 +1,5 @@
-import LogoWhiteGold from '@fundrbolt/shared/assets/logos/fundrbolt-logo-white-gold.svg'
 import { LegalFooter } from '@/components/legal/legal-footer'
+import LogoWhiteGold from '@fundrbolt/shared/assets/logos/fundrbolt-logo-white-gold.svg'
 
 type AuthLayoutProps = {
   children: React.ReactNode
@@ -10,8 +10,11 @@ export function AuthLayout({ children }: AuthLayoutProps) {
     <div className='flex min-h-svh flex-col'>
       <div className='container grid flex-1 items-center justify-center'>
         <div className='mx-auto flex w-full flex-col justify-center space-y-2 py-8 sm:w-[480px] sm:p-8'>
-          <div className='mb-4 flex items-center justify-center'>
+          <div className='mb-4 flex flex-col items-center justify-center gap-2'>
             <img src={LogoWhiteGold} alt='FundrBolt' className='h-12' />
+            <span className='text-muted-foreground text-sm font-medium uppercase tracking-widest'>
+              Admin Portal
+            </span>
           </div>
           {children}
         </div>

--- a/frontend/fundrbolt-admin/src/features/auth/complete-profile/index.tsx
+++ b/frontend/fundrbolt-admin/src/features/auth/complete-profile/index.tsx
@@ -8,7 +8,16 @@
  * Detection: localStorage flag `profile_setup_seen_<userId>` is
  * absent on first login; set when user completes or skips the prompt.
  */
-import { ProfilePictureUpload } from '@/components/profile/profile-picture-upload'
+import { useEffect, useState } from 'react'
+import { z } from 'zod'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate, useSearch } from '@tanstack/react-router'
+import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useAuthStore } from '@/stores/auth-store'
+import apiClient from '@/lib/axios'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -26,22 +35,13 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import { ProfilePictureUpload } from '@/components/profile/profile-picture-upload'
 import { AuthLayout } from '@/features/auth/auth-layout'
 import {
   SignUpWizard,
   type WizardStep,
 } from '@/features/auth/sign-up-wizard/SignUpWizard'
 import { PasswordChangeForm } from '@/features/settings/account/components/password-change-form'
-import apiClient from '@/lib/axios'
-import { useAuthStore } from '@/stores/auth-store'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useMutation } from '@tanstack/react-query'
-import { useNavigate, useSearch } from '@tanstack/react-router'
-import { Loader2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import { z } from 'zod'
 import { markProfileSetupSeen } from './utils'
 
 // ---------------------------------------------------------------------------

--- a/frontend/fundrbolt-admin/src/features/auth/password-reset-confirm/components/password-reset-confirm-form.tsx
+++ b/frontend/fundrbolt-admin/src/features/auth/password-reset-confirm/components/password-reset-confirm-form.tsx
@@ -1,3 +1,12 @@
+import { useState } from 'react'
+import { z } from 'zod'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useNavigate } from '@tanstack/react-router'
+import { ArrowRight, Eye, EyeOff, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import apiClient from '@/lib/axios'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
   Form,
@@ -9,15 +18,6 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import apiClient from '@/lib/axios'
-import { cn } from '@/lib/utils'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useNavigate } from '@tanstack/react-router'
-import { ArrowRight, Eye, EyeOff, Loader2 } from 'lucide-react'
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
-import { z } from 'zod'
 
 const formSchema = z
   .object({

--- a/frontend/fundrbolt-admin/src/features/auth/social-callback/index.tsx
+++ b/frontend/fundrbolt-admin/src/features/auth/social-callback/index.tsx
@@ -1,3 +1,9 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate, useSearch } from '@tanstack/react-router'
+import type { SocialAuthProvider } from '@fundrbolt/shared/types'
+import { Loader2 } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth-store'
+import { adminSocialAuthApi } from '@/lib/axios'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -9,12 +15,6 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { AuthLayout } from '@/features/auth/auth-layout'
-import { adminSocialAuthApi } from '@/lib/axios'
-import { useAuthStore } from '@/stores/auth-store'
-import type { SocialAuthProvider } from '@fundrbolt/shared/types'
-import { useNavigate, useSearch } from '@tanstack/react-router'
-import { Loader2 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
 
 type PendingInfo = {
   reason: string
@@ -179,15 +179,14 @@ export function SocialCallback() {
           setLinkError('Verification failed. Please try again.')
         }
       } catch (err: unknown) {
-        const message =
-          (
-            err as {
-              response?: { data?: { detail?: { message?: string } | string } }
-            }
-          )?.response?.data?.detail
+        const message = (
+          err as {
+            response?: { data?: { detail?: { message?: string } | string } }
+          }
+        )?.response?.data?.detail
         setLinkError(
           (typeof message === 'object' ? message?.message : message) ||
-          'Incorrect password. Please try again.'
+            'Incorrect password. Please try again.'
         )
       } finally {
         setLinking(false)
@@ -231,9 +230,7 @@ export function SocialCallback() {
                   <p className='text-destructive text-sm'>{linkError}</p>
                 )}
                 <Button type='submit' className='w-full' disabled={linking}>
-                  {linking && (
-                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                  )}
+                  {linking && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
                   {pending.reason === 'admin_step_up_required'
                     ? 'Confirm & Sign In'
                     : 'Link Account & Sign In'}
@@ -255,15 +252,18 @@ export function SocialCallback() {
             )}
             {pending.reason !== 'link_confirmation_required' &&
               pending.reason !== 'admin_step_up_required' && (
-              <Button
-                className='w-full'
-                onClick={() =>
-                  navigate({ to: '/sign-in', search: { redirect: undefined } })
-                }
-              >
-                Back to Sign In
-              </Button>
-            )}
+                <Button
+                  className='w-full'
+                  onClick={() =>
+                    navigate({
+                      to: '/sign-in',
+                      search: { redirect: undefined },
+                    })
+                  }
+                >
+                  Back to Sign In
+                </Button>
+              )}
           </CardContent>
         </Card>
       </AuthLayout>

--- a/frontend/fundrbolt-admin/src/features/auth/social-callback/index.tsx
+++ b/frontend/fundrbolt-admin/src/features/auth/social-callback/index.tsx
@@ -163,10 +163,16 @@ export function SocialCallback() {
       setLinking(true)
       setLinkError(null)
       try {
-        const result = await adminSocialAuthApi.confirmLink(
-          pending.attemptId,
-          linkPassword
-        )
+        const result =
+          pending.reason === 'admin_step_up_required'
+            ? await adminSocialAuthApi.confirmStepUp(
+                pending.attemptId,
+                linkPassword
+              )
+            : await adminSocialAuthApi.confirmLink(
+                pending.attemptId,
+                linkPassword
+              )
         if (result.status === 'authenticated') {
           handleSocialAuthSuccess({
             access_token: result.access_token,

--- a/frontend/fundrbolt-admin/src/features/auth/social-callback/index.tsx
+++ b/frontend/fundrbolt-admin/src/features/auth/social-callback/index.tsx
@@ -204,17 +204,13 @@ export function SocialCallback() {
             <CardDescription>{pending.message}</CardDescription>
           </CardHeader>
           <CardContent className='space-y-3'>
-            {pending.reason === 'admin_step_up_required' && (
-              <p className='text-muted-foreground text-sm'>
-                Admin accounts require additional identity verification. Please
-                confirm your password to complete sign-in.
-              </p>
-            )}
-            {pending.reason === 'link_confirmation_required' && (
+            {(pending.reason === 'link_confirmation_required' ||
+              pending.reason === 'admin_step_up_required') && (
               <form onSubmit={handleLinkConfirm} className='space-y-4'>
                 <p className='text-muted-foreground text-sm'>
-                  An account with this email already exists. Enter your password
-                  to link your social account and sign in.
+                  {pending.reason === 'admin_step_up_required'
+                    ? 'Admin accounts require additional identity verification. Please confirm your password to complete sign-in.'
+                    : 'An account with this email already exists. Enter your password to link your social account and sign in.'}
                 </p>
                 {pending.prefillEmail && (
                   <p className='text-sm font-medium'>{pending.prefillEmail}</p>
@@ -238,7 +234,9 @@ export function SocialCallback() {
                   {linking && (
                     <Loader2 className='mr-2 h-4 w-4 animate-spin' />
                   )}
-                  Link Account & Sign In
+                  {pending.reason === 'admin_step_up_required'
+                    ? 'Confirm & Sign In'
+                    : 'Link Account & Sign In'}
                 </Button>
                 <Button
                   type='button'
@@ -255,7 +253,8 @@ export function SocialCallback() {
                 </Button>
               </form>
             )}
-            {pending.reason !== 'link_confirmation_required' && (
+            {pending.reason !== 'link_confirmation_required' &&
+              pending.reason !== 'admin_step_up_required' && (
               <Button
                 className='w-full'
                 onClick={() =>

--- a/frontend/fundrbolt-admin/src/features/events/auction-items/AuctionItemsIndexPage.tsx
+++ b/frontend/fundrbolt-admin/src/features/events/auction-items/AuctionItemsIndexPage.tsx
@@ -2,31 +2,31 @@
  * AuctionItemsIndexPage
  * Page for listing all auction items for an event
  */
-import { BidCardSizeDialog } from '@/components/reports/BidCardSizeDialog'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate, useParams } from '@tanstack/react-router'
+import auctioneerService from '@/services/auctioneerService'
+import { reportService, type BidCardRequest } from '@/services/reportService'
+import revenueGeneratorService, {
+  type RGItem,
+} from '@/services/revenueGeneratorService'
+import { AuctionType, type AuctionItem } from '@/types/auction-item'
+import { Download, Loader2, Plus, Printer, Search, X } from 'lucide-react'
+import { toast } from 'sonner'
+import { useAuctionItemStore } from '@/stores/auctionItemStore'
 import { Button } from '@/components/ui/button'
 import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
+import { BidCardSizeDialog } from '@/components/reports/BidCardSizeDialog'
 import { AuctionItemList } from '@/features/events/components/AuctionItemList'
 import { RevenueGeneratorItemCard } from '@/features/events/components/RevenueGeneratorItemCard'
 import { useEventWorkspace } from '@/features/events/useEventWorkspace'
 import { RGItemForm } from '@/features/revenue-generators/RGItemForm'
-import auctioneerService from '@/services/auctioneerService'
-import { reportService, type BidCardRequest } from '@/services/reportService'
-import revenueGeneratorService, {
-    type RGItem,
-} from '@/services/revenueGeneratorService'
-import { useAuctionItemStore } from '@/stores/auctionItemStore'
-import { AuctionType, type AuctionItem } from '@/types/auction-item'
-import { useNavigate, useParams } from '@tanstack/react-router'
-import { Download, Loader2, Plus, Printer, Search, X } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { toast } from 'sonner'
 
 type TypeFilter = 'all' | 'live' | 'silent' | 'revenue_generators'
 
@@ -189,7 +189,9 @@ export function AuctionItemsIndexPage() {
       link.click()
       window.URL.revokeObjectURL(url)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to export PowerPoint')
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to export PowerPoint'
+      )
     }
   }
 
@@ -203,7 +205,9 @@ export function AuctionItemsIndexPage() {
       link.click()
       window.URL.revokeObjectURL(url)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to export PowerPoint')
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to export PowerPoint'
+      )
     }
   }
 

--- a/frontend/fundrbolt-admin/src/lib/axios.ts
+++ b/frontend/fundrbolt-admin/src/lib/axios.ts
@@ -1,6 +1,4 @@
-import { isRetryableError, retryWithBackoff } from '@/lib/retry'
-import { useAuthStore } from '@/stores/auth-store'
-import { useDebugSpoofStore } from '@/stores/debug-spoof-store'
+import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios'
 import type {
   SocialAuthCallbackRequest,
   SocialAuthCallbackResponse,
@@ -10,7 +8,9 @@ import type {
   SocialAuthStartResponse,
 } from '@fundrbolt/shared/types'
 import { sanitizeRequestPayload } from '@fundrbolt/shared/utils'
-import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios'
+import { useAuthStore } from '@/stores/auth-store'
+import { useDebugSpoofStore } from '@/stores/debug-spoof-store'
+import { isRetryableError, retryWithBackoff } from '@/lib/retry'
 
 // Global flag to track if consent modal is already shown
 let consentModalShown = false
@@ -289,7 +289,7 @@ apiClient.interceptors.response.use(
     if (error.response?.status === 429) {
       const retryAfter = error.response.headers['retry-after']
       if (retryAfter) {
-        ; (error as AxiosError & { retryAfter?: number }).retryAfter = parseInt(
+        ;(error as AxiosError & { retryAfter?: number }).retryAfter = parseInt(
           retryAfter,
           10
         )

--- a/frontend/fundrbolt-admin/src/lib/axios.ts
+++ b/frontend/fundrbolt-admin/src/lib/axios.ts
@@ -346,6 +346,16 @@ export const adminSocialAuthApi = {
     )
     return response.data
   },
+  confirmStepUp: async (
+    attemptId: string,
+    password: string
+  ): Promise<SocialAuthCallbackResponse> => {
+    const response = await apiClient.post<SocialAuthCallbackResponse>(
+      '/auth/social/admin-step-up',
+      { attempt_id: attemptId, password }
+    )
+    return response.data
+  },
 }
 
 export default apiClient

--- a/frontend/fundrbolt-admin/src/main.tsx
+++ b/frontend/fundrbolt-admin/src/main.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react'
 import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
 import { AxiosError } from 'axios'
@@ -9,6 +8,7 @@ import {
 } from '@tanstack/react-query'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { useGlobalInputSanitizer } from '@fundrbolt/shared/hooks'
+import * as Sentry from '@sentry/react'
 import { toast } from 'sonner'
 import { useAuthStore } from '@/stores/auth-store'
 import { handleServerError } from '@/lib/handle-server-error'

--- a/frontend/fundrbolt-admin/src/routes/__root.tsx
+++ b/frontend/fundrbolt-admin/src/routes/__root.tsx
@@ -1,15 +1,16 @@
+import { type QueryClient } from '@tanstack/react-query'
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+import { InstallPromptBanner } from '@fundrbolt/shared/pwa/install-prompt-banner'
+import { PullToRefresh } from '@fundrbolt/shared/pwa/pull-to-refresh'
+import { UpdateNotification } from '@fundrbolt/shared/pwa/update-notification'
+import { useServiceWorker } from '@fundrbolt/shared/pwa/use-service-worker'
+import { Toaster } from '@/components/ui/sonner'
 import { ConnectionStatus } from '@/components/ConnectionStatus'
 import { CookieConsentWrapper } from '@/components/legal/cookie-consent-wrapper'
 import { NavigationProgress } from '@/components/navigation-progress'
 import { SessionExpirationWarning } from '@/components/session-expiration-warning'
-import { Toaster } from '@/components/ui/sonner'
 import { GeneralError } from '@/features/errors/general-error'
 import { NotFoundError } from '@/features/errors/not-found-error'
-import { InstallPromptBanner } from '@fundrbolt/shared/pwa/install-prompt-banner'
-import { UpdateNotification } from '@fundrbolt/shared/pwa/update-notification'
-import { useServiceWorker } from '@fundrbolt/shared/pwa/use-service-worker'
-import { type QueryClient } from '@tanstack/react-query'
-import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient
@@ -26,6 +27,7 @@ function RootComponent() {
     <>
       <NavigationProgress />
       <ConnectionStatus />
+      <PullToRefresh />
       <SessionExpirationWarning />
       <CookieConsentWrapper />
       <UpdateNotification

--- a/frontend/fundrbolt-admin/src/routes/__root.tsx
+++ b/frontend/fundrbolt-admin/src/routes/__root.tsx
@@ -1,15 +1,15 @@
-import { type QueryClient } from '@tanstack/react-query'
-import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
-import { InstallPromptBanner } from '@fundrbolt/shared/pwa/install-prompt-banner'
-import { UpdateNotification } from '@fundrbolt/shared/pwa/update-notification'
-import { useServiceWorker } from '@fundrbolt/shared/pwa/use-service-worker'
-import { Toaster } from '@/components/ui/sonner'
 import { ConnectionStatus } from '@/components/ConnectionStatus'
 import { CookieConsentWrapper } from '@/components/legal/cookie-consent-wrapper'
 import { NavigationProgress } from '@/components/navigation-progress'
 import { SessionExpirationWarning } from '@/components/session-expiration-warning'
+import { Toaster } from '@/components/ui/sonner'
 import { GeneralError } from '@/features/errors/general-error'
 import { NotFoundError } from '@/features/errors/not-found-error'
+import { InstallPromptBanner } from '@fundrbolt/shared/pwa/install-prompt-banner'
+import { UpdateNotification } from '@fundrbolt/shared/pwa/update-notification'
+import { useServiceWorker } from '@fundrbolt/shared/pwa/use-service-worker'
+import { type QueryClient } from '@tanstack/react-query'
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient
@@ -29,7 +29,7 @@ function RootComponent() {
       <SessionExpirationWarning />
       <CookieConsentWrapper />
       <UpdateNotification
-        needRefresh={needRefresh}
+        needRefresh={!import.meta.env.DEV && needRefresh}
         onRefresh={updateServiceWorker}
         onDismiss={dismissUpdate}
       />

--- a/frontend/fundrbolt-admin/src/services/auctioneerService.ts
+++ b/frontend/fundrbolt-admin/src/services/auctioneerService.ts
@@ -1,5 +1,5 @@
-import apiClient from '@/lib/axios'
 import { type SlidePresentationLayout } from '@/types/auction-item'
+import apiClient from '@/lib/axios'
 
 export interface CommissionUpsertRequest {
   commission_percent: number

--- a/frontend/fundrbolt-admin/src/services/reportService.ts
+++ b/frontend/fundrbolt-admin/src/services/reportService.ts
@@ -29,34 +29,34 @@ const LABEL_SIZE_OPTIONS: {
   label: string
   description: string
 }[] = [
-    { value: '2x3', label: '2" × 3"', description: 'Small badge / shelf label' },
-    {
-      value: '2x4',
-      label: '2" × 4"',
-      description: 'Standard address label (Brady 3456)',
-    },
-    { value: '3x3', label: '3" × 3"', description: 'Square label' },
-    {
-      value: '3x5',
-      label: '3" × 5"',
-      description: 'Index card / large bid card (recommended)',
-    },
-    {
-      value: 'tent-8.5x11',
-      label: 'Tent — short fold (landscape)',
-      description: 'Folds on the short side · 11"×4.25" faces (1 per sheet)',
-    },
-    {
-      value: 'tent-8.5x11-long',
-      label: 'Tent — long fold (portrait)',
-      description: 'Folds on the long side · 8.5"×5.5" faces (1 per sheet)',
-    },
-    {
-      value: 'tent-8.5x11-2up',
-      label: 'Tent 2-up (landscape)',
-      description: 'Two tent cards per sheet — cut along dashed line',
-    },
-  ]
+  { value: '2x3', label: '2" × 3"', description: 'Small badge / shelf label' },
+  {
+    value: '2x4',
+    label: '2" × 4"',
+    description: 'Standard address label (Brady 3456)',
+  },
+  { value: '3x3', label: '3" × 3"', description: 'Square label' },
+  {
+    value: '3x5',
+    label: '3" × 5"',
+    description: 'Index card / large bid card (recommended)',
+  },
+  {
+    value: 'tent-8.5x11',
+    label: 'Tent — short fold (landscape)',
+    description: 'Folds on the short side · 11"×4.25" faces (1 per sheet)',
+  },
+  {
+    value: 'tent-8.5x11-long',
+    label: 'Tent — long fold (portrait)',
+    description: 'Folds on the long side · 8.5"×5.5" faces (1 per sheet)',
+  },
+  {
+    value: 'tent-8.5x11-2up',
+    label: 'Tent 2-up (landscape)',
+    description: 'Two tent cards per sheet — cut along dashed line',
+  },
+]
 
 export { LABEL_SIZE_OPTIONS }
 

--- a/frontend/fundrbolt-admin/src/stores/auth-store.ts
+++ b/frontend/fundrbolt-admin/src/stores/auth-store.ts
@@ -252,11 +252,16 @@ export const useAuthStore = create<AuthState>()(
         })
         // Fetch full user profile via an API call
         apiClient
-          .get('/auth/me')
+          .get('/users/me')
           .then((response) => {
             set({ user: response.data })
           })
-          .catch(() => {
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.error(
+              '[auth] Failed to load user profile after social auth:',
+              err
+            )
             // User data will be populated on next page load
           })
       },

--- a/frontend/fundrbolt-admin/src/stores/auth-store.ts
+++ b/frontend/fundrbolt-admin/src/stores/auth-store.ts
@@ -1,7 +1,7 @@
+import apiClient from '@/lib/axios'
+import { useDebugSpoofStore } from '@/stores/debug-spoof-store'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { useDebugSpoofStore } from '@/stores/debug-spoof-store'
-import apiClient from '@/lib/axios'
 
 interface AuthUser {
   id: string

--- a/frontend/fundrbolt-admin/src/stores/cookie-store.ts
+++ b/frontend/fundrbolt-admin/src/stores/cookie-store.ts
@@ -7,6 +7,7 @@ import type {
   CookieConsentPreferences,
   CookieConsentStatusResponse,
 } from '@/types/cookie'
+import { create } from 'zustand'
 import {
   clearSessionId,
   getCookiePreferences,
@@ -14,7 +15,6 @@ import {
   hasSetCookiePreferences,
   saveCookiePreferences,
 } from '@/utils/cookie-manager'
-import { create } from 'zustand'
 
 interface CookieConsentState {
   preferences: CookieConsentPreferences

--- a/frontend/fundrbolt-admin/src/styles/index.css
+++ b/frontend/fundrbolt-admin/src/styles/index.css
@@ -19,6 +19,9 @@
     @apply text-foreground has-[div[data-variant='inset']]:bg-sidebar min-h-svh w-full;
     background-color: #11294c !important;
     font-family: var(--font-sans);
+    overflow-y: auto;
+    overscroll-behavior-y: none;
+    -webkit-overflow-scrolling: touch;
   }
 
   /* Override Radix scroll locking for sticky headers */

--- a/frontend/fundrbolt-admin/src/vite-env.d.ts
+++ b/frontend/fundrbolt-admin/src/vite-env.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/react" />
 
+declare const __APP_VERSION__: string
+
 interface ImportMetaEnv {
   readonly VITE_BUY_NOW_PRICE_MULTIPLIER?: string
 }

--- a/frontend/fundrbolt-admin/tsconfig.json
+++ b/frontend/fundrbolt-admin/tsconfig.json
@@ -10,15 +10,9 @@
   ],
   "compilerOptions": {
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@fundrbolt/shared": [
-        "../shared/src/index.ts"
-      ],
-      "@fundrbolt/shared/*": [
-        "../shared/src/*"
-      ]
+      "@/*": ["./src/*"],
+      "@fundrbolt/shared": ["../shared/src/index.ts"],
+      "@fundrbolt/shared/*": ["../shared/src/*"]
     }
   }
 }

--- a/frontend/fundrbolt-admin/vite.config.ts
+++ b/frontend/fundrbolt-admin/vite.config.ts
@@ -1,17 +1,19 @@
+import path from 'path'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react-swc'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
-import react from '@vitejs/plugin-react-swc'
 import { execSync } from 'child_process'
-import path from 'path'
-import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { version } from './package.json'
 
 // Auto-generate version: major.minor from package.json, patch from git commit count
 function buildVersion() {
   try {
-    const commitCount = execSync('git rev-list HEAD --count', { encoding: 'utf8' }).trim()
+    const commitCount = execSync('git rev-list HEAD --count', {
+      encoding: 'utf8',
+    }).trim()
     const [major, minor] = version.split('.')
     return `${major}.${minor}.${commitCount}`
   } catch {
@@ -36,7 +38,7 @@ export default defineConfig({
     react(),
     tailwindcss(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       devOptions: {
         enabled: true,
         type: 'module',
@@ -123,15 +125,15 @@ export default defineConfig({
     // Upload source maps to Sentry only when SENTRY_AUTH_TOKEN is set (i.e. in CI)
     ...(process.env.SENTRY_AUTH_TOKEN
       ? [
-        sentryVitePlugin({
-          org: process.env.SENTRY_ORG,
-          project: 'fundrbolt-admin',
-          authToken: process.env.SENTRY_AUTH_TOKEN,
-          sourcemaps: {
-            filesToDeleteAfterUpload: ['./dist/**/*.map'],
-          },
-        }),
-      ]
+          sentryVitePlugin({
+            org: process.env.SENTRY_ORG,
+            project: 'fundrbolt-admin',
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            sourcemaps: {
+              filesToDeleteAfterUpload: ['./dist/**/*.map'],
+            },
+          }),
+        ]
       : []),
   ],
   resolve: {

--- a/frontend/fundrbolt-admin/vite.config.ts
+++ b/frontend/fundrbolt-admin/vite.config.ts
@@ -1,13 +1,31 @@
-import path from 'path'
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
+import react from '@vitejs/plugin-react-swc'
+import { execSync } from 'child_process'
+import path from 'path'
+import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
-import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { version } from './package.json'
+
+// Auto-generate version: major.minor from package.json, patch from git commit count
+function buildVersion() {
+  try {
+    const commitCount = execSync('git rev-list HEAD --count', { encoding: 'utf8' }).trim()
+    const [major, minor] = version.split('.')
+    return `${major}.${minor}.${commitCount}`
+  } catch {
+    return version
+  }
+}
+
+const appVersion = buildVersion()
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   plugins: [
     tanstackRouter({
       target: 'react',
@@ -105,15 +123,15 @@ export default defineConfig({
     // Upload source maps to Sentry only when SENTRY_AUTH_TOKEN is set (i.e. in CI)
     ...(process.env.SENTRY_AUTH_TOKEN
       ? [
-          sentryVitePlugin({
-            org: process.env.SENTRY_ORG,
-            project: 'fundrbolt-admin',
-            authToken: process.env.SENTRY_AUTH_TOKEN,
-            sourcemaps: {
-              filesToDeleteAfterUpload: ['./dist/**/*.map'],
-            },
-          }),
-        ]
+        sentryVitePlugin({
+          org: process.env.SENTRY_ORG,
+          project: 'fundrbolt-admin',
+          authToken: process.env.SENTRY_AUTH_TOKEN,
+          sourcemaps: {
+            filesToDeleteAfterUpload: ['./dist/**/*.map'],
+          },
+        }),
+      ]
       : []),
   ],
   resolve: {

--- a/infrastructure/bicep/main-beta.bicep
+++ b/infrastructure/bicep/main-beta.bicep
@@ -233,11 +233,11 @@ module apiApp './modules/container-app.bicep' = {
     targetPort: 8000
     stickySessionsEnabled: true // Required for Socket.IO
     envVars: concat(commonEnvVars, [
-      { name: 'FRONTEND_ADMIN_URL', value: 'https://app.${customDomain}' }
-      { name: 'FRONTEND_DONOR_URL', value: 'https://give.${customDomain}' }
+      { name: 'FRONTEND_ADMIN_URL', value: 'https://admin.${customDomain}' }
+      { name: 'FRONTEND_DONOR_URL', value: 'https://app.${customDomain}' }
       {
         name: 'CORS_ORIGINS'
-        value: 'https://app.${customDomain},https://give.${customDomain},https://${customDomain},https://www.${customDomain}'
+        value: 'https://admin.${customDomain},https://app.${customDomain},https://give.${customDomain},https://${customDomain},https://www.${customDomain}'
       }
     ])
     secretEnvVars: commonSecretEnvVars


### PR DESCRIPTION
- **fix: eagerly load user.role in social auth to fix admin Microsoft sign-in**
- **feat: show version number and update banner on admin sign-in screen**
- **fix: show Microsoft account picker on sign-in (add prompt=select_account)**
- **fix: show password form for admin_step_up_required in social callback**
- **fix: show password form for admin_step_up_required in social callback**
- **feat: add pull-to-refresh and fix update banner on admin PWA**
- **fix: admin step-up social login uses password verification instead of opaque token**
- **fix: social auth profile fetch - use /users/me instead of /auth/me**
- **fix: Apple relay redirects to correct frontend (admin vs donor) based on app_context**
- **fix: Facebook sign-in relay + Apple relay app_context comparison**
- **fix: replace flyout sub-menus with inline accordion in profile dropdown to fix mobile overflow**
- **fix: replace flyout sub-menus with inline accordion in profile dropdown to fix mobile overflow**
- **fix(admin): fix event icon chip and auctioneer sticky header**
- **fix: correct FRONTEND_ADMIN_URL in Bicep (admin.fundrbolt.com not app.fundrbolt.com)**
