### PR TITLE
fix: admin PWA social auth comms email display, complete-profile wizard, and version increment

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/frontend/fundrbolt-admin/src/components/layout/nav-user.tsx
+++ b/frontend/fundrbolt-admin/src/components/layout/nav-user.tsx
@@ -1,7 +1,4 @@
-import { Link } from '@tanstack/react-router'
-import { ChevronsUpDown, LogOut } from 'lucide-react'
-import { useAuthStore } from '@/stores/auth-store'
-import useDialogState from '@/hooks/use-dialog-state'
+import { SignOutDialog } from '@/components/sign-out-dialog'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
   DropdownMenu,
@@ -17,7 +14,10 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from '@/components/ui/sidebar'
-import { SignOutDialog } from '@/components/sign-out-dialog'
+import useDialogState from '@/hooks/use-dialog-state'
+import { useAuthStore } from '@/stores/auth-store'
+import { Link } from '@tanstack/react-router'
+import { ChevronsUpDown, LogOut } from 'lucide-react'
 
 type NavUserProps = {
   user: {
@@ -36,6 +36,7 @@ export function NavUser({ user }: NavUserProps) {
   const authUser = useAuthStore((state) => state.user)
 
   const profilePictureUrl = getProfilePictureUrl()
+  const displayEmail = authUser?.communications_email?.trim() || user.email
   const initials = authUser
     ? `${authUser.first_name?.[0] || ''}${authUser.last_name?.[0] || ''}`.toUpperCase()
     : 'SN'
@@ -61,7 +62,7 @@ export function NavUser({ user }: NavUserProps) {
                 </Avatar>
                 <div className='grid flex-1 text-start text-sm leading-tight'>
                   <span className='truncate font-semibold'>{user.name}</span>
-                  <span className='truncate text-xs'>{user.email}</span>
+                  <span className='truncate text-xs'>{displayEmail}</span>
                 </div>
                 <ChevronsUpDown className='ms-auto size-4' />
               </SidebarMenuButton>
@@ -85,7 +86,7 @@ export function NavUser({ user }: NavUserProps) {
                   </Avatar>
                   <div className='grid flex-1 text-start text-sm leading-tight'>
                     <span className='truncate font-semibold'>{user.name}</span>
-                    <span className='truncate text-xs'>{user.email}</span>
+                    <span className='truncate text-xs'>{displayEmail}</span>
                   </div>
                 </div>
               </DropdownMenuLabel>

--- a/frontend/fundrbolt-admin/src/features/auth/complete-profile/index.tsx
+++ b/frontend/fundrbolt-admin/src/features/auth/complete-profile/index.tsx
@@ -14,7 +14,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation } from '@tanstack/react-query'
 import { useNavigate, useSearch } from '@tanstack/react-router'
-import { Loader2 } from 'lucide-react'
+import { CheckCircle2, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAuthStore } from '@/stores/auth-store'
 import apiClient from '@/lib/axios'
@@ -43,6 +43,36 @@ import {
 } from '@/features/auth/sign-up-wizard/SignUpWizard'
 import { PasswordChangeForm } from '@/features/settings/account/components/password-change-form'
 import { markProfileSetupSeen } from './utils'
+
+// ---------------------------------------------------------------------------
+// Storage helpers for pending comms email OTP
+// ---------------------------------------------------------------------------
+
+const PENDING_COMMS_EMAIL_KEY = 'admin_pending_comms_email_verification'
+
+function getPendingCommsEmail(): string | null {
+  try {
+    return window.sessionStorage.getItem(PENDING_COMMS_EMAIL_KEY)
+  } catch {
+    return null
+  }
+}
+
+function setPendingCommsEmail(email: string): void {
+  try {
+    window.sessionStorage.setItem(PENDING_COMMS_EMAIL_KEY, email)
+  } catch {
+    // ignore
+  }
+}
+
+function clearPendingCommsEmail(): void {
+  try {
+    window.sessionStorage.removeItem(PENDING_COMMS_EMAIL_KEY)
+  } catch {
+    // ignore
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -103,6 +133,197 @@ type CompleteProfileFormData = z.infer<typeof completeProfileSchema>
 const WIZARD_STEPS: WizardStep[] = [{ id: 'profile', label: 'Your Profile' }]
 
 // ---------------------------------------------------------------------------
+// Communications email sub-component
+// ---------------------------------------------------------------------------
+
+type CommsEmailState =
+  | { step: 'idle'; verifiedEmail: string | null }
+  | { step: 'entering'; email: string }
+  | { step: 'otp'; email: string }
+  | { step: 'verified'; email: string }
+
+function CommunicationsEmailSection({
+  onVerified,
+}: {
+  onVerified?: () => void
+}) {
+  const user = useAuthStore((state) => state.user)
+  const setUser = useAuthStore((state) => state.setUser)
+
+  const initialVerified =
+    user?.communications_email_verified && user.communications_email
+      ? user.communications_email
+      : null
+  const restoredPendingEmail = getPendingCommsEmail()
+
+  const [state, setState] = useState<CommsEmailState>(
+    initialVerified
+      ? { step: 'verified', email: initialVerified }
+      : restoredPendingEmail
+        ? { step: 'otp', email: restoredPendingEmail }
+        : { step: 'idle', verifiedEmail: null }
+  )
+  const [inputEmail, setInputEmail] = useState(
+    restoredPendingEmail || user?.communications_email || user?.email || ''
+  )
+  const [otp, setOtp] = useState('')
+  const [otpError, setOtpError] = useState('')
+
+  const requestMutation = useMutation({
+    mutationFn: (email: string) =>
+      apiClient.post('/users/me/communications-email/request-verification', {
+        email,
+      }),
+    onSuccess: (_response, email) => {
+      setPendingCommsEmail(email)
+      setState({ step: 'otp', email })
+      setInputEmail(email)
+      toast.success(`Verification code sent to ${email}`)
+    },
+    onError: () =>
+      toast.error('Failed to send verification code. Please try again.'),
+  })
+
+  const confirmMutation = useMutation({
+    mutationFn: (code: string) =>
+      apiClient.post('/users/me/communications-email/confirm', { otp: code }),
+    onSuccess: () => {
+      if (state.step === 'otp') {
+        clearPendingCommsEmail()
+        setState({ step: 'verified', email: state.email })
+        setUser(
+          user
+            ? {
+              ...user,
+              communications_email: state.email,
+              communications_email_verified: true,
+            }
+            : null
+        )
+        toast.success('Communications email verified!')
+        onVerified?.()
+      }
+    },
+    onError: () => {
+      setOtpError('That code is incorrect or has expired. Try again.')
+    },
+  })
+
+  if (state.step === 'verified') {
+    return (
+      <div className='space-y-1.5'>
+        <label className='text-sm font-medium'>Email</label>
+        <div className='flex items-center gap-2'>
+          <Input
+            value={state.email}
+            readOnly
+            disabled
+            className='bg-muted text-muted-foreground'
+          />
+          <CheckCircle2 className='h-5 w-5 shrink-0 text-green-600' />
+        </div>
+        <button
+          type='button'
+          className='text-primary text-xs underline'
+          onClick={() => {
+            clearPendingCommsEmail()
+            setState({ step: 'entering', email: state.email })
+            setInputEmail(state.email)
+            setOtp('')
+            setOtpError('')
+          }}
+        >
+          Change
+        </button>
+      </div>
+    )
+  }
+
+  if (state.step === 'otp') {
+    return (
+      <div className='space-y-1.5'>
+        <label className='text-sm font-medium'>Enter verification code</label>
+        <p className='text-muted-foreground text-xs'>
+          We sent a 6-digit code to <strong>{state.email}</strong>.
+        </p>
+        <div className='flex gap-2'>
+          <Input
+            value={otp}
+            onChange={(e) => {
+              setOtp(e.target.value.replace(/\D/g, '').slice(0, 6))
+              setOtpError('')
+            }}
+            placeholder='123456'
+            inputMode='numeric'
+            maxLength={6}
+            className='w-36'
+          />
+          <Button
+            type='button'
+            size='sm'
+            disabled={otp.length !== 6 || confirmMutation.isPending}
+            onClick={() => confirmMutation.mutate(otp)}
+          >
+            {confirmMutation.isPending ? (
+              <Loader2 className='h-4 w-4 animate-spin' />
+            ) : (
+              'Verify'
+            )}
+          </Button>
+        </div>
+        {otpError && <p className='text-destructive text-xs'>{otpError}</p>}
+        <p className='text-muted-foreground text-xs'>
+          You can enter the code here now, or come back later from the link in
+          the email.
+        </p>
+        <button
+          type='button'
+          className='text-primary text-xs underline'
+          onClick={() => {
+            setPendingCommsEmail(state.email)
+            requestMutation.mutate(state.email)
+          }}
+          disabled={requestMutation.isPending}
+        >
+          Resend code
+        </button>
+      </div>
+    )
+  }
+
+  // idle or entering
+  return (
+    <div className='space-y-1.5'>
+      <label className='text-sm font-medium'>Email</label>
+      <div className='flex gap-2'>
+        <Input
+          type='email'
+          inputMode='email'
+          placeholder='personal@example.com'
+          value={inputEmail}
+          onChange={(e) => setInputEmail(e.target.value)}
+        />
+        <Button
+          type='button'
+          size='sm'
+          disabled={!inputEmail || requestMutation.isPending}
+          onClick={() => requestMutation.mutate(inputEmail)}
+        >
+          {requestMutation.isPending ? (
+            <Loader2 className='h-4 w-4 animate-spin' />
+          ) : (
+            'Send code'
+          )}
+        </Button>
+      </div>
+      <p className='text-muted-foreground text-xs'>
+        Where we'll send event notifications and updates.
+      </p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -113,6 +334,13 @@ export function CompleteProfile() {
   const user = useAuthStore((state) => state.user)
   const setUser = useAuthStore((state) => state.setUser)
   const [pictureUploaded, setPictureUploaded] = useState(false)
+
+  // Start at step 2 if email already verified
+  const alreadyVerified =
+    !!user?.communications_email_verified && !!user?.communications_email
+  const [profileStep, setProfileStep] = useState<'email' | 'profile'>(
+    alreadyVerified ? 'profile' : 'email'
+  )
 
   // Mark as seen on mount — navigating away (e.g. browser back) without
   // clicking Skip should still prevent future redirects to this page.
@@ -172,6 +400,10 @@ export function CompleteProfile() {
     updateProfileMutation.mutate(data)
   }
 
+  const handleSkipEmailStep = () => {
+    setProfileStep('profile')
+  }
+
   const handleSkip = () => {
     if (user) markProfileSetupSeen(user.id)
     navigate({ to: redirectTo })
@@ -182,6 +414,41 @@ export function CompleteProfile() {
   const userInitials =
     `${user.first_name?.[0] ?? ''}${user.last_name?.[0] ?? ''}`.toUpperCase()
 
+  // ── Step 1: verify communications email ──────────────────────────────────
+  if (profileStep === 'email' && !alreadyVerified) {
+    return (
+      <AuthLayout>
+        <Card className='gap-4'>
+          <CardHeader>
+            <CardTitle className='text-lg tracking-tight'>
+              Where should we send updates?
+            </CardTitle>
+            <CardDescription>
+              Enter and verify the email address where you'd like to receive
+              notifications and updates.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className='space-y-4'>
+              <CommunicationsEmailSection
+                onVerified={() => setProfileStep('profile')}
+              />
+              <Button
+                type='button'
+                variant='ghost'
+                className='w-full'
+                onClick={handleSkipEmailStep}
+              >
+                Skip for now
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </AuthLayout>
+    )
+  }
+
+  // ── Step 2: profile details ───────────────────────────────────────────────
   return (
     <AuthLayout>
       <Card className='gap-4'>
@@ -252,7 +519,6 @@ export function CompleteProfile() {
                             }
                             onChange={(e) => {
                               const raw = e.target.value.replace(/\D/g, '')
-                              // Only prepend +1 if the user is entering a US number (10 digits)
                               if (!raw) {
                                 field.onChange('')
                               } else if (raw.length === 10) {

--- a/frontend/fundrbolt-admin/src/routes/_authenticated/settings/support.tsx
+++ b/frontend/fundrbolt-admin/src/routes/_authenticated/settings/support.tsx
@@ -1,11 +1,3 @@
-import { useState } from 'react'
-import { z } from 'zod'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { createFileRoute } from '@tanstack/react-router'
-import { LifeBuoy, Mail, Send } from 'lucide-react'
-import { toast } from 'sonner'
-import { useAuthStore } from '@/stores/auth-store'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -32,6 +24,14 @@ import {
 } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { ContentSection } from '@/features/settings/components/content-section'
+import { useAuthStore } from '@/stores/auth-store'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { createFileRoute } from '@tanstack/react-router'
+import { LifeBuoy, Mail, Send } from 'lucide-react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
 
 const SUPPORT_EMAIL = 'support@fundrbolt.com'
 
@@ -219,6 +219,10 @@ function SettingsSupport() {
           </CardContent>
         </Card>
       </ContentSection>
+
+      <p className='text-muted-foreground/50 text-center text-xs tabular-nums'>
+        v{__APP_VERSION__}
+      </p>
     </div>
   )
 }

--- a/frontend/fundrbolt-admin/src/stores/auth-store.ts
+++ b/frontend/fundrbolt-admin/src/stores/auth-store.ts
@@ -11,6 +11,8 @@ interface AuthUser {
   last_name: string
   email_verified: boolean
   role: string
+  communications_email?: string | null
+  communications_email_verified?: boolean
   npo_memberships: {
     npo_id: string
     npo_name: string


### PR DESCRIPTION
## Summary

### Apple Sign In / Social Auth fixes
- ****: Show `communications_email` in the profile menu sidebar instead of the raw OAuth email (fixes Apple private relay email showing up). Falls back to `user.email` if no comms email set — same pattern as donor PWA.
- **`auth-store.ts`**: Added `communications_email` and `communications_email_verified` to the `AuthUser` type so the fields are available after `/users/me` populates the store.
- **`complete-profile/index.tsx`**: Rewrote the first-time profile wizard to match donor PWA two-step flow:
  1. **Step 1** — "Where should we send updates?" — enter and OTP-verify a communications email
  2. **Step 2** — Original profile form (photo, org, phone, social links, recovery password)
  Users who already have a verified comms email skip straight to step 2.

### Version display fixes
- **`settings/support.tsx`**: Added `v{__APP_VERSION__}` at the bottom of the support page.
- **`.github/workflows/frontend-deploy.yml`**: Added `fetch-depth: 0` to the checkout step so `git rev-list HEAD --count` returns the real commit count instead of always `1`, fixing the version stuck at `v2.2.1`.